### PR TITLE
svlogd : config file directory fix / log directory has an attribut

### DIFF
--- a/libraries/resource_runit_service.rb
+++ b/libraries/resource_runit_service.rb
@@ -39,7 +39,8 @@ class Chef
         @sv_bin = runit_node[:sv_bin] || '/usr/bin/sv'
         @sv_dir = runit_node[:sv_dir] || '/etc/sv'
         @service_dir = runit_node[:service_dir] || '/etc/service'
-        @lsb_init_dir = runit_node[:lsb_init_dir] || '/etc/init.d'
+        @syslog_dir = runit_node[:syslog_dir]  || "" #|| "#{@sv_dir}/#{@name}"
+	@lsb_init_dir = runit_node[:lsb_init_dir] || '/etc/init.d'
 
         @control = []
         @options = {}
@@ -111,6 +112,10 @@ class Chef
 
       def service_dir(arg=nil)
         set_or_return(:service_dir, arg, :kind_of => [String])
+      end
+
+      def syslog_dir(arg=nil)
+        set_or_return(:syslog_dir, arg, :kind_of => [String])
       end
 
       def lsb_init_dir(arg=nil)

--- a/libraries/resource_runit_service.rb
+++ b/libraries/resource_runit_service.rb
@@ -39,8 +39,8 @@ class Chef
         @sv_bin = runit_node[:sv_bin] || '/usr/bin/sv'
         @sv_dir = runit_node[:sv_dir] || '/etc/sv'
         @service_dir = runit_node[:service_dir] || '/etc/service'
+        @lsb_init_dir = runit_node[:lsb_init_dir] || '/etc/init.d'
         @syslog_dir = runit_node[:syslog_dir]  || "" #|| "#{@sv_dir}/#{@name}"
-	@lsb_init_dir = runit_node[:lsb_init_dir] || '/etc/init.d'
 
         @control = []
         @options = {}


### PR DESCRIPTION
Actually the config file for svlogd is not in the good place, so that svlogd can't be configured.
My patches fix that, 
I also add the possibility to choose with an attribute named syslog_dir, the path of the default log files. No more '/var/log' hardcoded. The default svlogd behaviour has been hardcoded when no syslog_dir attrbute has been definned.