### PR TITLE
Skip runit installation if already installed

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -60,7 +60,7 @@ when 'rhel'
     rpm_installed = "rpm -qa | grep -q '^runit'"
     cookbook_file "#{Chef::Config[:file_cache_path]}/runit-2.1.1.tar.gz" do
       source 'runit-2.1.1.tar.gz'
-      not_if rpm_installed
+      not_if { rpm_installed || File.executable?(node['runit']['executable']) }
       notifies :run, 'bash[rhel_build_install]', :immediately
     end
 
@@ -75,7 +75,7 @@ when 'rhel'
         rpm -ivh "${rpm_root_dir}/runit-2.1.1.rpm"
       EOH
       action :run
-      not_if rpm_installed
+      not_if { rpm_installed || File.executable?(node['runit']['executable']) }
     end
   end
 


### PR DESCRIPTION
If there is an executable at the desired installation location, we can assume that runit is already installed. Unfortunately, I can't find a way to verify that the *correct version* is installed, but given that the version isn't configurable via attributes, it seems reasonable that when/if there ever is a new version of runit, this logic can be changed.

I don't know how to test this effectively, give the current minitest-based suite. If you have any thoughts I'd be happy to write some tests.

Cheers!