### PR TITLE
Move log config file from log service dir into log dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,9 @@ Many of these parameters are only used in the `:enable` action.
    script. Default is true.
 - **default_logger** - Whether a default `log/run` script should be set
    up. If true, the default content of the run script will use
-   `svlogd` to write logs to `/var/log/service_name`. Default is false.
+   `svlogd` to write logs to `log_dir`. Default is false.
+- **log_dir** - The directory where the `svlogd` log service will run.  Used to
+  create `svlogd`'s `config` file.  Default is `/var/log/service_name`.
 - **log_size** - The maximum size a log file can grow to before it is
   automatically rotated.  See svlogd(8) for the default value.
 - **log_num** - The maximum number of log files that will be retained

--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -298,7 +298,7 @@ class Chef
 
         def default_logger_content
           "#!/bin/sh
-exec svlogd -tt /var/log/#{new_resource.service_name}"
+exec svlogd -tt '#{new_resource.log_dir}'"
         end
 
         #
@@ -348,7 +348,7 @@ exec svlogd -tt /var/log/#{new_resource.service_name}"
 
         def default_log_dir
           return @default_log_dir unless @default_log_dir.nil?
-          @default_log_dir = Chef::Resource::Directory.new(::File.join("/var/log/#{new_resource.service_name}"), run_context)
+          @default_log_dir = Chef::Resource::Directory.new(new_resource.log_dir, run_context)
           @default_log_dir.recursive(true)
           @default_log_dir.owner(new_resource.owner)
           @default_log_dir.group(new_resource.group)

--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -292,10 +292,6 @@ class Chef
           ::File.join(new_resource.service_dir, new_resource.service_name)
         end
 
-        def log_dir_name
-          ::File.join(new_resource.service_dir, new_resource.service_name, log)
-        end
-
         def template_cookbook
           new_resource.cookbook.nil? ? new_resource.cookbook_name.to_s : new_resource.cookbook
         end

--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -384,7 +384,7 @@ exec svlogd -tt '#{new_resource.log_dir}'"
 
         def log_config_file
           return @log_config_file unless @log_config_file.nil?
-          @log_config_file = Chef::Resource::Template.new(::File.join(sv_dir_name, 'log', 'config'), run_context)
+          @log_config_file = Chef::Resource::Template.new(::File.join(new_resource.log_dir, 'config'), run_context)
           @log_config_file.owner(new_resource.owner)
           @log_config_file.group(new_resource.group)
           @log_config_file.mode(00644)

--- a/libraries/resource_runit_service.rb
+++ b/libraries/resource_runit_service.rb
@@ -63,6 +63,7 @@ class Chef
         @sv_templates = true
         @sv_timeout = nil
         @sv_verbose = false
+        @log_dir = ::File.join('/var/log', @service_name)
         @log_size = nil
         @log_num = nil
         @log_min = nil
@@ -203,6 +204,10 @@ class Chef
 
       def sv_templates(arg = nil)
         set_or_return(:sv_templates, arg, :kind_of => [TrueClass, FalseClass])
+      end
+
+      def log_dir(arg = nil)
+        set_or_return(:log_dir, arg, :kind_of => [String])
       end
 
       def log_size(arg = nil)

--- a/test/spec/libraries/provider_runit_service_spec.rb
+++ b/test/spec/libraries/provider_runit_service_spec.rb
@@ -239,7 +239,7 @@ describe Chef::Provider::Service::Runit do
 
       it 'creates log/run with default content if default_logger parameter is true' do
         new_resource.log_dir('/opt/noodles/log')
-        script_content = "exec svlogd -tt #{new_resource.log_dir}"
+        script_content = "exec svlogd -tt '#{new_resource.log_dir}'"
         new_resource.default_logger(true)
         provider.send(:log_run_script).path.should eq(::File.join(sv_dir_name, 'log', 'run'))
         provider.send(:log_run_script).owner.should eq(new_resource.owner)

--- a/test/spec/libraries/provider_runit_service_spec.rb
+++ b/test/spec/libraries/provider_runit_service_spec.rb
@@ -226,7 +226,10 @@ describe Chef::Provider::Service::Runit do
         provider.send(:log_run_script).mode.should eq(00755)
         provider.send(:log_run_script).source.should eq("sv-#{new_resource.log_template_name}-log-run.erb")
         provider.send(:log_run_script).cookbook.should be_empty
-        provider.send(:log_config_file).path.should eq(::File.join(sv_dir_name, 'log', 'config'))
+      end
+
+      it 'creates log config file in log_dir' do
+        provider.send(:log_config_file).path.should eq(::File.join(new_resource.log_dir, 'config'))
         provider.send(:log_config_file).owner.should eq(new_resource.owner)
         provider.send(:log_config_file).group.should eq(new_resource.group)
         provider.send(:log_config_file).mode.should eq(00644)

--- a/test/spec/libraries/provider_runit_service_spec.rb
+++ b/test/spec/libraries/provider_runit_service_spec.rb
@@ -235,14 +235,15 @@ describe Chef::Provider::Service::Runit do
       end
 
       it 'creates log/run with default content if default_logger parameter is true' do
-        script_content = "exec svlogd -tt /var/log/#{new_resource.service_name}"
+        new_resource.log_dir('/opt/noodles/log')
+        script_content = "exec svlogd -tt #{new_resource.log_dir}"
         new_resource.default_logger(true)
         provider.send(:log_run_script).path.should eq(::File.join(sv_dir_name, 'log', 'run'))
         provider.send(:log_run_script).owner.should eq(new_resource.owner)
         provider.send(:log_run_script).group.should eq(new_resource.group)
         provider.send(:log_run_script).mode.should eq(00755)
         provider.send(:log_run_script).content.should include(script_content)
-        provider.send(:default_log_dir).path.should eq(::File.join('/var', 'log', new_resource.service_name))
+        provider.send(:default_log_dir).path.should eq(new_resource.log_dir)
         provider.send(:default_log_dir).recursive.should be_true
         provider.send(:default_log_dir).owner.should eq(new_resource.owner)
         provider.send(:default_log_dir).group.should eq(new_resource.group)

--- a/test/spec/libraries/resource_runit_service_spec.rb
+++ b/test/spec/libraries/resource_runit_service_spec.rb
@@ -272,6 +272,15 @@ describe Chef::Resource::RunitService do
     resource.sv_verbose.should eq(true)
   end
 
+  it 'has a log_dir parameter that defaults to "/var/log/service_name"' do
+    resource.log_dir.should eq(::File.join('/var/log', resource.service_name))
+  end
+
+  it 'has an log_dir parameter that can be set' do
+    resource.log_dir('/opt/noodles/log')
+    resource.log_dir.should eq('/opt/noodles/log')
+  end
+
   it 'has a log_size parameter to control the maximum log size' do
     resource.log_size(1_000_000)
     resource.log_size.should eq(1_000_000)

--- a/test/spec/libraries/resource_runit_service_spec.rb
+++ b/test/spec/libraries/resource_runit_service_spec.rb
@@ -273,7 +273,7 @@ describe Chef::Resource::RunitService do
   end
 
   it 'has a log_dir parameter that defaults to "/var/log/service_name"' do
-    resource.log_dir.should eq(::File.join('/var/log', resource.service_name))
+    resource.log_dir.should eq('/var/log/getty.service')
   end
 
   it 'has an log_dir parameter that can be set' do


### PR DESCRIPTION
This PR is an alternate implementation of #47 (the difference being this PR includes tests). It would fix #69 and #75.

The core issue being addressed is that the all the `log_*` parameters offered by the recipe do not work.  The recipe places the `config` file in the log service directory, but the `config` needs to go into the actual log directory. The `svlogd` documentation [is clear about this](http://smarden.org/runit/svlogd.8.html):

> On startup [...] **svlogd** checks for each log directory *log* if the configuration file *log/config* exists, and if so, reads the file line by line [...]

In addition, this PR adds a new recipe parameter, `log_dir`, which lets the user override the default log directory path.