### PR TITLE
Add helper methods to detect installation presence

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,0 +1,45 @@
+#
+# Cookbook:: runit
+# Libraries:: helpers
+#
+# Author: Joshua Timberman <joshua@getchef.com>
+# Copyright (c) 2014, Chef Software, Inc. <legal@getchef.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/mixin/shell_out'
+include Chef::Mixin::ShellOut
+module Runit
+  module Helpers
+    def runit_installed?
+      return true if runit_rpm_installed? || (runit_executable? && runit_sv_works?)
+    end
+
+    def runit_executable?
+      ::File.executable?(node['runit']['executable'])
+    end
+
+    def runit_sv_works?
+      sv = shell_out("#{node['runit']['sv_bin']} --help")
+      sv.exitstatus == 100 && sv.stderr =~ /usage: sv .* command service/
+    end
+
+    def runit_rpm_installed?
+      shell_out('rpm -qa | grep -q "^runit"').exitstatus == 0
+    end
+  end
+end
+
+Chef::Recipe.send(:include, Runit::Helpers)
+Chef::Resource.send(:include, Runit::Helpers)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -57,13 +57,17 @@ when 'rhel'
       package 'buildsys-macros'
     end
 
-    rpm_installed = "rpm -qa | grep -q '^runit'"
+    # This is the rpm spec and associated files to build a package of
+    # runit from source; the package will be installed.
     cookbook_file "#{Chef::Config[:file_cache_path]}/runit-2.1.1.tar.gz" do
       source 'runit-2.1.1.tar.gz'
-      not_if rpm_installed
+      not_if { runit_installed? }
       notifies :run, 'bash[rhel_build_install]', :immediately
     end
 
+    # This bash resource does the rpm install because we need to
+    # dynamically detect where the rpm output directory is from the
+    # rpm config directive '%{_rpmdir}'
     bash 'rhel_build_install' do
       user 'root'
       cwd Chef::Config[:file_cache_path]
@@ -75,7 +79,7 @@ when 'rhel'
         rpm -ivh "${rpm_root_dir}/runit-2.1.1.rpm"
       EOH
       action :run
-      not_if rpm_installed
+      not_if { runit_installed? }
     end
   end
 


### PR DESCRIPTION
If a user is installing runit from source in a base image, as brought
up in #62, they probably want to skip the build and installation of
the package. We detect that runit is already installed in a robust
way:

* if the rpm is already installed, keeping the logic we had already
* if the `runit` executable is actually executable, AND the `sv`
  command works (`sv` will return 100 when run with `--help` and have
  usage information on STDERR.)