### PR TITLE
Fix hardcoded sv_bin in runit_service on Debian

### DIFF
--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -521,7 +521,11 @@ exec svlogd -tt /var/log/#{new_resource.service_name}"
                 t.mode(00755)
                 t.cookbook('runit')
                 t.source('init.d.erb')
-                t.variables(:name => new_resource.service_name)
+                t.variables(
+                  :name => new_resource.service_name,
+                  :sv_bin => new_resource.sv_bin,
+                  :init_dir => ::File.join(new_resource.lsb_init_dir, '')
+                )
                 t
               else
                 l = Chef::Resource::Link.new(initfile, run_context)

--- a/templates/debian/init.d.erb
+++ b/templates/debian/init.d.erb
@@ -13,8 +13,8 @@
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="runit-managed <%= @name %>"
 NAME=<%= @name %>
-RUNIT=/usr/bin/sv
-SCRIPTNAME=/etc/init.d/$NAME
+RUNIT=<%= @sv_bin %>
+SCRIPTNAME=<%= @init_dir %>$NAME
 
 # Exit if runit is not installed
 [ -x $RUNIT ] || exit 0


### PR DESCRIPTION
On Debian the init.d file created by runit_service hardcodes the sv_bin
to /usr/bin/sv. This breakes runit when there is no sv in /usr/bin.

This also fixes the hardcoded scriptname in the init.d template.

Fixes #92.