### PR TITLE
Fixes "Cannot find a resource for shell_out!" when using runit_send_s…

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -19,6 +19,8 @@
 # limitations under the License.
 #
 
+include Chef::Mixin::ShellOut
+
 module RunitCookbook
   module Helpers
     # Default settings for resource properties.


### PR DESCRIPTION
…ignal

Trace below seen on various occassions and os flavors:
================================================================================
Error executing action `term` on resource 'runit_service[mcollective]'
================================================================================


NameError
---------
Cannot find a resource for shell_out! on redhat version 6.4


Cookbook Trace:
---------------
/chef/vendored-cookbooks/runit/libraries/helpers.rb:91:in `block in runit_send_signal'
/chef/vendored-cookbooks/runit/libraries/helpers.rb:90:in `runit_send_signal'
/chef/vendored-cookbooks/runit/libraries/provider_runit_service.rb:229:in `block (2 levels) in <class:RunitService>'