### PR TITLE
Fixes #120, implement restart action

### DIFF
--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -250,6 +250,10 @@ class Chef
 
       action :nothing do
       end
-    end
+
+      action :restart do
+        restart_service
+      end
+   end
   end
 end

--- a/test/cookbooks/runit_test/recipes/service.rb
+++ b/test/cookbooks/runit_test/recipes/service.rb
@@ -144,17 +144,22 @@ end
 
 # Despite waiting for runit to create supervise/ok, sometimes services
 # are supervised, but not actually fully started
-# ruby_block 'sleep 5s to allow services to be fully started' do
-#   block do
-#     sleep 5
-#   end
-# end
+ruby_block 'sleep 5s to allow services to be fully started' do
+  block do
+    sleep 5
+  end
+end
 
 # # Notify the plain defaults service as a normal service resource
-# file '/tmp/notifier' do
-#   content Time.now.to_s
-#   notifies :restart, 'service[plain-defaults]', :immediately
-# end
+file '/tmp/notifier' do
+  content Time.now.to_s
+  notifies :restart, 'service[plain-defaults]', :immediately
+end
+
+file '/tmp/notifier-2' do
+  content Time.now.to_s
+  notifies :restart, 'runit_service[plain-defaults]', :immediately
+end
 
 # # Test for COOK-2867
 # link '/etc/init.d/cook-2867' do


### PR DESCRIPTION
In the #107 refactor, it appears that the restart action implementation went missing. It probably "just worked" for restarting, e.g., `service[thing]` but not `runit_service[thing]`. I also uncommented the 5 second sleep ruby block to ensure all services are up, as well as the notifier file creation that notifies a `service` to restart, and added another notifier for a `runit_service`.

Please review @cwjohnston @slyness @someara 