### PR TITLE
Restore support for alternative sv_bin on debian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ UNRELEASED
 ----------
 * Modernize runit_service provider by rewriting pure Ruby as LWRP
 * Modernize integration tests by rewriting Minitest suites as ServerSpec
+* Fix regression in support for alternate sv binary on debian platforms
 
 v1.6.0 (2015-04-06)
 --------------------

--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -193,7 +193,11 @@ class Chef
               mode '00755'
               cookbook 'runit'
               source 'init.d.erb'
-              variables(name: new_resource.service_name)
+              variables(
+                name: new_resource.service_name,
+                sv_bin: new_resource.sv_bin,
+                init_dir: ::File.join(parsed_lsb_init_dir, '')
+              )
               action :create
             end
           else

--- a/templates/debian/init.d.erb
+++ b/templates/debian/init.d.erb
@@ -13,8 +13,8 @@
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="runit-managed <%= @name %>"
 NAME=<%= @name %>
-RUNIT=/usr/bin/sv
-SCRIPTNAME=/etc/init.d/$NAME
+RUNIT=<%= @sv_bin %>
+SCRIPTNAME=<%= @init_dir %>$NAME
 
 # Exit if runit is not installed
 [ -x $RUNIT ] || exit 0

--- a/test/cookbooks/runit_test/recipes/service.rb
+++ b/test/cookbooks/runit_test/recipes/service.rb
@@ -19,6 +19,10 @@
 
 include_recipe 'runit::default'
 
+link '/usr/local/bin/sv' do
+  to '/usr/bin/sv'
+end
+
 package 'netcat' do
   package_name 'nc' if platform_family?('rhel', 'fedora')
 end
@@ -173,3 +177,8 @@ end
 # runit_service 'cook-2867' do
 #   default_logger true
 # end
+
+# create a service using an alternate sv binary
+runit_service 'alternative-sv-bin' do
+  sv_bin '/usr/local/bin/sv'
+end

--- a/test/cookbooks/runit_test/templates/default/sv-alternative-sv-bin-log-run.erb
+++ b/test/cookbooks/runit_test/templates/default/sv-alternative-sv-bin-log-run.erb
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec svlogd -tt ./main

--- a/test/cookbooks/runit_test/templates/default/sv-alternative-sv-bin-run.erb
+++ b/test/cookbooks/runit_test/templates/default/sv-alternative-sv-bin-run.erb
@@ -1,0 +1,3 @@
+#!/bin/sh
+exec 2>&1
+exec nc -l 3008

--- a/test/integration/service/serverspec/debian_spec.rb
+++ b/test/integration/service/serverspec/debian_spec.rb
@@ -262,4 +262,16 @@ if %w( debian ).include? os[:family]
     end
   end
 
+  # alternative-sv-bin
+  describe 'creates a service with an alternative sv_bin' do
+    describe command('ps -ef | grep -v grep | grep "runsv alternative-sv-bin"') do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should match(/runsv alternative-sv-bin/) }
+    end
+
+    describe file('/etc/init.d/alternative-sv-bin') do
+      its(:content) { should match(/^RUNIT=\/usr\/local\/bin\/sv$/) }
+    end
+  end
+
 end

--- a/test/integration/service/serverspec/linux_spec.rb
+++ b/test/integration/service/serverspec/linux_spec.rb
@@ -271,4 +271,17 @@ if %w( redhat fedora ubuntu ).include? os[:family]
     end
   end
 
+  # alternative-sv-bin
+  describe 'creates a service with an alternative sv_bin' do
+    describe command('ps -ef | grep -v grep | grep "runsv alternative-sv-bin"') do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should match(/runsv alternative-sv-bin/) }
+    end
+
+    describe file('/etc/init.d/alternative-sv-bin') do
+      it { should be_symlink }
+      it { should be_linked_to('/usr/local/bin/sv') }
+    end
+  end
+
 end


### PR DESCRIPTION
This change seeks to reinstate the changes contained in #93, addressing #92, #98. Includes integration test coverage.