### PR TITLE
fix unreliable test for gzipped log data by using socat

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,6 +9,8 @@ platforms:
     run_list:
     - recipe[yum-epel]
   - name: centos-6.6
+    run_list:
+    - recipe[yum-epel]
   - name: centos-7.0
   - name: fedora-21
   - name: ubuntu-10.04

--- a/test/cookbooks/runit_test/recipes/service.rb
+++ b/test/cookbooks/runit_test/recipes/service.rb
@@ -23,6 +23,8 @@ link '/usr/local/bin/sv' do
   to '/usr/bin/sv'
 end
 
+package 'socat'
+
 package 'netcat' do
   package_name 'nc' if platform_family?('rhel', 'fedora')
 end
@@ -62,7 +64,7 @@ end
 # Create a service that uses the default svlog
 runit_service 'default-svlog' do
   default_logger true
-  log_size 100000 # smallish 10k
+  log_size 10000 # smallish 10k
   log_num 12
   log_processor 'gzip'
 end

--- a/test/cookbooks/runit_test/templates/default/sv-default-svlog-run.erb
+++ b/test/cookbooks/runit_test/templates/default/sv-default-svlog-run.erb
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec nc -l 6701
+exec socat - TCP4-LISTEN:6701,fork

--- a/test/integration/service/serverspec/debian_spec.rb
+++ b/test/integration/service/serverspec/debian_spec.rb
@@ -73,6 +73,15 @@ if %w( debian ).include? os[:family]
     end
   end
 
+  # Send some random data to the service logs and wait for logs to be written
+  describe command('dd if=/dev/urandom bs=5K count=10 | strings --bytes=1 | socat - "TCP4:127.0.0.1:6701" && sleep 2') do
+    its(:exit_status) { should eq 0 }
+  end
+
+  describe command('file /var/log/default-svlog/*.s') do
+    its(:stdout) { should contain('gzip compressed data') }
+  end
+
   # checker
   describe 'creates a service that has a check script' do
     describe command('ps -ef | grep -v grep | grep "runsv checker"') do

--- a/test/integration/service/serverspec/linux_spec.rb
+++ b/test/integration/service/serverspec/linux_spec.rb
@@ -73,7 +73,7 @@ if %w( redhat fedora ubuntu ).include? os[:family]
     end
 
     # Send some random data to the service logs and wait for logs to be written
-    describe command('dd if=/dev/urandom bs=5K count=10 | strings --bytes=1 | nc localhost 6701 && sleep 2') do
+    describe command('dd if=/dev/urandom bs=5K count=10 | strings --bytes=1 | socat - "TCP4:127.0.0.1:6701" && sleep 2') do
       its(:exit_status) { should eq 0 }
     end
 


### PR DESCRIPTION
Fixes unreliable test introduced in #117. For reasons yet unknown, netcat outputs far less data than we expect to receive, so the log rotation conditions were not being met. Using `socat` seems to work as expected.