### PR TITLE
include Chef::Mixin::ShellOut in the Chef::Recipe scope

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -19,10 +19,16 @@
 # limitations under the License.
 #
 
-::Chef::Recipe.send(:include, Chef::Mixin::ShellOut)
-
 module RunitCookbook
   module Helpers
+
+    # include Chef::Mixin::ShellOut if it is not already included in the calling class
+    def self.included(klass)
+      unless(klass.ancestors.include?(Chef::Mixin::ShellOut))
+        klass.class_eval{ include Chef::Mixin::ShellOut }
+      end
+    end
+
     # Default settings for resource properties.
     def parsed_sv_bin
       return new_resource.sv_bin if new_resource.sv_bin

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -19,6 +19,8 @@
 # limitations under the License.
 #
 
+::Chef::Recipe.send(:include, Chef::Mixin::ShellOut)
+
 module RunitCookbook
   module Helpers
     # Default settings for resource properties.


### PR DESCRIPTION
Alternative for fix in #118, intended to improve compatability with versions of Chef prior to 12.