### PR TITLE
Restore sanity by using example groups for common serverspec tests

### DIFF
--- a/test/integration/default/serverspec/linux_spec.rb
+++ b/test/integration/default/serverspec/linux_spec.rb
@@ -1,6 +1,4 @@
-require 'serverspec'
-
-set :backend, :exec
+require 'spec_helper'
 
 puts "os: #{os}"
 

--- a/test/integration/helpers/serverspec/service_example_groups.rb
+++ b/test/integration/helpers/serverspec/service_example_groups.rb
@@ -1,0 +1,242 @@
+require 'spec_helper'
+
+shared_examples_for 'common runit_test services' do
+
+  # no-svlog
+  describe 'creates a service that doesnt use the svlog' do
+    describe command('ps -ef | grep -v grep | grep "runsv no-svlog"') do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should match(/runsv no-svlog/) }
+    end
+
+    describe file('/etc/service/no-svlog/log') do
+      it { should_not be_directory }
+    end
+  end
+
+  # default-svlog
+  describe 'creates a service that uses the default svlog' do
+    describe command('ps -ef | grep -v grep | grep "runsv default-svlog"') do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should match(/runsv default-svlog/) }
+    end
+
+    describe file('/etc/service/default-svlog/log/run') do
+      it { should be_mode 755 }
+      it { should be_owned_by 'root' }
+      it { should be_grouped_into 'root' }
+      regexp = %r{#!/bin/sh\nexec svlogd -tt /var/log/default-svlog}
+      its(:content) { should match regexp }
+    end
+
+    # Send some random data to the service logs and wait for logs to be written
+    describe command('dd if=/dev/urandom bs=5K count=10 | strings --bytes=1 | socat - "TCP4:127.0.0.1:6701" && sleep 2') do
+      its(:exit_status) { should eq 0 }
+    end
+
+    describe command('file /var/log/default-svlog/*.s') do
+      its(:stdout) { should contain('gzip compressed data') }
+    end
+  end
+
+  # checker
+  describe 'creates a service that has a check script' do
+    describe command('ps -ef | grep -v grep | grep "runsv checker"') do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should match(/runsv checker/) }
+    end
+
+    describe file('/etc/service/checker/check') do
+      it { should be_mode 755 }
+      it { should be_owned_by 'root' }
+      it { should be_grouped_into 'root' }
+    end
+  end
+
+  # finisher
+  describe 'creates a service that has a finish script' do
+    describe command('ps -ef | grep -v grep | grep "runsv finisher"') do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should match(/runsv finisher/) }
+    end
+
+    describe file('/etc/service/finisher/finish') do
+      it { should be_mode 755 }
+      it { should be_owned_by 'root' }
+      it { should be_grouped_into 'root' }
+    end
+  end
+
+  # env-files
+  describe 'creates a service that uses env files' do
+    describe command('ps -ef | grep -v grep | grep "runsv env-files"') do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should match(/runsv env-files/) }
+    end
+
+    describe file('/etc/service/env-files/env/PATH') do
+      it { should be_mode 640 }
+      it { should be_owned_by 'root' }
+      it { should be_grouped_into 'root' }
+      regexp = %r{\$PATH:/opt/chef/embedded/bin}
+      its(:content) { should match regexp }
+    end
+  end
+
+  # template-options
+  describe 'creates a service that sets options for the templates' do
+    describe command('ps -ef | grep -v grep | grep "runsv template-options"') do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should match(/runsv template-options/) }
+    end
+
+    describe file('/etc/service/template-options/run') do
+      it { should be_mode 755 }
+      it { should be_owned_by 'root' }
+      it { should be_grouped_into 'root' }
+      regexp = '# Options are delicious'
+      its(:content) { should match regexp }
+    end
+  end
+
+  # control-signals
+  describe 'creates a service that uses control signal files' do
+    describe command('ps -ef | grep -v grep | grep "runsv control-signals"') do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should match(/runsv control-signals/) }
+    end
+
+    describe file('/etc/service/control-signals/control/u') do
+      it { should be_mode 755 }
+      it { should be_owned_by 'root' }
+      it { should be_grouped_into 'root' }
+      regexp = 'control signal up'
+      its(:content) { should match regexp }
+    end
+  end
+
+  # runsvdir-floyd
+  describe 'creates a runsvdir service for a normal user' do
+    describe command('ps -ef | grep -v grep | grep "runsv runsvdir-floyd"') do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should match(/runsv runsvdir-floyd/) }
+    end
+
+    describe file('/etc/service/runsvdir-floyd/run') do
+      it { should be_mode 755 }
+      it { should be_owned_by 'root' }
+      it { should be_grouped_into 'root' }
+      regexp = %r{exec chpst -ufloyd runsvdir /home/floyd/service}
+      its(:content) { should match regexp }
+    end
+  end
+
+  # timer
+  describe 'creates a service using sv_timeout' do
+    describe command('ps -ef | grep -v grep | grep "runsv timer"') do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should match(/runsv timer/) }
+    end
+    # FIXME: add something here
+  end
+
+  # chatterbox
+  describe 'creates a service using sv_verbose' do
+    describe command('ps -ef | grep -v grep | grep "runsv chatterbox"') do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should match(/runsv chatterbox/) }
+    end
+    # FIXME: add something here
+  end
+
+  # yerba
+  describe 'creates a service with differently named template files' do
+    describe command('ps -ef | grep -v grep | grep "runsv yerba"') do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should match(/runsv yerba/) }
+    end
+    # FIXME: add something here
+  end
+
+  # yerba-alt
+  describe 'creates a service with differently named run script template' do
+    describe command('ps -ef | grep -v grep | grep "runsv yerba-alt"') do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should match(/runsv yerba-alt/) }
+    end
+    # FIXME: add something here
+  end
+
+  # ayahuasca
+  describe 'creates a service with a template from another cookbook' do
+    describe command('ps -ef | grep -v grep | grep "runsv ayahuasca"') do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should match(/runsv ayahuasca/) }
+    end
+  end
+
+  # exist-disabled
+  describe 'creates a service that should exist but be disabled' do
+    describe command('ps -ef | grep -v grep | grep "runsv control-signals"') do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should_not match(/runsv exist-disabled/) }
+    end
+
+    describe file('/etc/sv/exist-disabled/run') do
+      it { should be_mode 755 }
+      it { should be_owned_by 'root' }
+      it { should be_grouped_into 'root' }
+    end
+  end
+
+  # downed service
+  describe 'creates and manages down file for service' do
+    describe 'creates a service with a default state of down' do
+      describe file('/etc/sv/downed-service-6702/run') do
+        it { should be_mode 755 }
+        it { should be_owned_by 'root' }
+        it { should be_grouped_into 'root' }
+      end
+
+      describe file('/etc/service/downed-service-6702') do
+        it { should be_symlink }
+        it { should be_owned_by 'root' }
+        it { should be_grouped_into 'root' }
+      end
+
+      describe file('/etc/sv/downed-service-6702/down') do
+        it { should be_mode 644 }
+        it { should be_owned_by 'root' }
+        it { should be_grouped_into 'root' }
+      end
+
+      describe command('ps -ef | grep -v grep | grep "runsv downed-service-6702"') do
+        its(:exit_status) { should eq 0 }
+        its(:stdout) { should match(/runsv downed-service-6702/) }
+      end
+
+      describe command('netstat -tuplen | grep LISTEN | grep 6702') do
+        its(:exit_status) { should eq 1 }
+      end
+    end
+
+    describe 'leaves existing downfile in place when down true -> false' do
+      describe file('/etc/sv/un-downed-service/down') do
+        it { should be_mode 644 }
+        it { should be_owned_by 'root' }
+        it { should be_grouped_into 'root' }
+      end
+
+      describe command('ps -ef | grep -v grep | grep "runsv un-downed-service"') do
+        its(:exit_status) { should eq 0 }
+        its(:stdout) { should match(/runsv un-downed-service/) }
+      end
+    end
+    describe 'removes existing downfile when requested' do
+      describe file('/etc/sv/un-downed-service-deleted/down') do
+        it { should_not exist }
+      end
+    end
+  end
+
+end

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -1,0 +1,4 @@
+require 'serverspec'
+set :backend, :exec
+
+puts "os: #{os}"

--- a/test/integration/service/serverspec/debian_spec.rb
+++ b/test/integration/service/serverspec/debian_spec.rb
@@ -1,286 +1,104 @@
-require 'serverspec'
-
-set :backend, :exec
-
-puts "os: #{os}"
+require 'spec_helper'
+require 'service_example_groups'
 
 if %w( debian ).include? os[:family]
 
-  # plain-defaults
-  describe 'creates a service with the defaults' do
-    describe command('ps -ef | grep -v grep | grep "runsv plain-defaults"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should match(/runsv plain-defaults/) }
-    end
+  describe "runit_test::service on #{os}" do
 
-    describe file('/etc/init.d/plain-defaults') do
-      it { should be_mode 755 }
-      it { should be_owned_by 'root' }
-      it { should be_grouped_into 'root' }
-    end
+    # plain-defaults
+    describe 'creates a service with the defaults' do
+      describe command('ps -ef | grep -v grep | grep "runsv plain-defaults"') do
+        its(:exit_status) { should eq 0 }
+        its(:stdout) { should match(/runsv plain-defaults/) }
+      end
 
-    describe file('/etc/service/plain-defaults') do
-      it { should be_symlink }
-      it { should be_owned_by 'root' }
-      it { should be_grouped_into 'root' }
-    end
+      describe file('/etc/init.d/plain-defaults') do
+        it { should be_mode 755 }
+        it { should be_owned_by 'root' }
+        it { should be_grouped_into 'root' }
+      end
 
-    describe file('/etc/service/plain-defaults/run') do
-      it { should be_mode 755 }
-      it { should be_owned_by 'root' }
-      it { should be_grouped_into 'root' }
-    end
+      describe file('/etc/service/plain-defaults') do
+        it { should be_symlink }
+        it { should be_owned_by 'root' }
+        it { should be_grouped_into 'root' }
+      end
 
-    describe file('/etc/service/plain-defaults/log') do
-      it { should be_directory }
-      it { should be_mode 755 }
-      it { should be_owned_by 'root' }
-      it { should be_grouped_into 'root' }
-    end
+      describe file('/etc/service/plain-defaults/run') do
+        it { should be_mode 755 }
+        it { should be_owned_by 'root' }
+        it { should be_grouped_into 'root' }
+      end
 
-    describe file('/etc/service/plain-defaults/log/run') do
-      it { should be_mode 755 }
-      it { should be_owned_by 'root' }
-      it { should be_grouped_into 'root' }
-    end
-  end
+      describe file('/etc/service/plain-defaults/log') do
+        it { should be_directory }
+        it { should be_mode 755 }
+        it { should be_owned_by 'root' }
+        it { should be_grouped_into 'root' }
+      end
 
-  # no-svlog
-  describe 'creates a service that doesnt use the svlog' do
-    describe command('ps -ef | grep -v grep | grep "runsv no-svlog"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should match(/runsv no-svlog/) }
-    end
+      describe file('/etc/service/plain-defaults/log/run') do
+        it { should be_mode 755 }
+        it { should be_owned_by 'root' }
+        it { should be_grouped_into 'root' }
+      end
 
-    describe file('/etc/service/no-svlog/log') do
-      it { should_not be_directory }
-    end
-  end
+      it_behaves_like 'common runit_test services'
 
-  # default-svlog
-  describe 'creates a service that uses the default svlog' do
-    describe command('ps -ef | grep -v grep | grep "runsv default-svlog"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should match(/runsv default-svlog/) }
-    end
+      # the following specs are a little different on debian vs other distros,
+      # so they are not part of the common services example group
 
-    describe file('/etc/service/default-svlog/log/run') do
-      it { should be_mode 755 }
-      it { should be_owned_by 'root' }
-      it { should be_grouped_into 'root' }
-      regexp = %r{#!/bin/sh\nexec svlogd -tt /var/log/default-svlog}
-      its(:content) { should match regexp }
-    end
-  end
+      # alternative-sv-bin
+      describe 'creates a service with an alternative sv_bin' do
+        describe command('ps -ef | grep -v grep | grep "runsv alternative-sv-bin"') do
+          its(:exit_status) { should eq 0 }
+          its(:stdout) { should match(/runsv alternative-sv-bin/) }
+        end
 
-  # Send some random data to the service logs and wait for logs to be written
-  describe command('dd if=/dev/urandom bs=5K count=10 | strings --bytes=1 | socat - "TCP4:127.0.0.1:6701" && sleep 2') do
-    its(:exit_status) { should eq 0 }
-  end
+        describe file('/etc/init.d/alternative-sv-bin') do
+          its(:content) { should match(/^RUNIT=\/usr\/local\/bin\/sv$/) }
+        end
+      end
 
-  describe command('file /var/log/default-svlog/*.s') do
-    its(:stdout) { should contain('gzip compressed data') }
-  end
+      # floyds-app
+      describe 'creates a service running by a normal user in its runsvdir' do
+        describe command('ps -ef | grep -v grep | grep "runsv floyds-app"') do
+          its(:exit_status) { should eq 0 }
+          its(:stdout) { should match(/runsv floyds-app/) }
+        end
 
-  # checker
-  describe 'creates a service that has a check script' do
-    describe command('ps -ef | grep -v grep | grep "runsv checker"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should match(/runsv checker/) }
-    end
+        describe file('/etc/init.d/floyds-app') do
+          it { should be_mode 755 }
+          it { should be_owned_by 'root' }
+          it { should be_grouped_into 'root' }
+        end
 
-    describe file('/etc/service/checker/check') do
-      it { should be_mode 755 }
-      it { should be_owned_by 'root' }
-      it { should be_grouped_into 'root' }
-    end
-  end
+        describe file('/home/floyd/service/floyds-app') do
+          it { should be_symlink }
+          it { should be_owned_by 'root' }
+          it { should be_grouped_into 'root' }
+        end
 
-  # finisher
-  describe 'creates a service that has a finish script' do
-    describe command('ps -ef | grep -v grep | grep "runsv finisher"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should match(/runsv finisher/) }
-    end
+        describe file('/home/floyd/service/floyds-app/run') do
+          it { should be_mode 755 }
+          it { should be_owned_by 'floyd' }
+          it { should be_grouped_into 'floyd' }
+        end
 
-    describe file('/etc/service/finisher/finish') do
-      it { should be_mode 755 }
-      it { should be_owned_by 'root' }
-      it { should be_grouped_into 'root' }
+        describe file('/home/floyd/service/floyds-app/log') do
+          it { should be_directory }
+          it { should be_mode 755 }
+          it { should be_owned_by 'floyd' }
+          it { should be_grouped_into 'floyd' }
+        end
+
+        describe file('/home/floyd/service/floyds-app/log/run') do
+          it { should be_mode 755 }
+          it { should be_owned_by 'floyd' }
+          it { should be_grouped_into 'floyd' }
+        end
+      end
+
     end
   end
-
-  # env-files
-  describe 'creates a service that uses env files' do
-    describe command('ps -ef | grep -v grep | grep "runsv env-files"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should match(/runsv env-files/) }
-    end
-
-    describe file('/etc/service/env-files/env/PATH') do
-      it { should be_mode 640 }
-      it { should be_owned_by 'root' }
-      it { should be_grouped_into 'root' }
-      regexp = %r{\$PATH:/opt/chef/embedded/bin}
-      its(:content) { should match regexp }
-    end
-  end
-
-  # template-options
-  describe 'creates a service that sets options for the templates' do
-    describe command('ps -ef | grep -v grep | grep "runsv template-options"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should match(/runsv template-options/) }
-    end
-
-    describe file('/etc/service/template-options/run') do
-      it { should be_mode 755 }
-      it { should be_owned_by 'root' }
-      it { should be_grouped_into 'root' }
-      regexp = '# Options are delicious'
-      its(:content) { should match regexp }
-    end
-  end
-
-  # control-signals
-  describe 'creates a service that uses control signal files' do
-    describe command('ps -ef | grep -v grep | grep "runsv control-signals"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should match(/runsv control-signals/) }
-    end
-
-    describe file('/etc/service/control-signals/control/u') do
-      it { should be_mode 755 }
-      it { should be_owned_by 'root' }
-      it { should be_grouped_into 'root' }
-      regexp = 'control signal up'
-      its(:content) { should match regexp }
-    end
-  end
-
-  # runsvdir-floyd
-  describe 'creates a runsvdir service for a normal user' do
-    describe command('ps -ef | grep -v grep | grep "runsv runsvdir-floyd"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should match(/runsv runsvdir-floyd/) }
-    end
-
-    describe file('/etc/service/runsvdir-floyd/run') do
-      it { should be_mode 755 }
-      it { should be_owned_by 'root' }
-      it { should be_grouped_into 'root' }
-      regexp = %r{exec chpst -ufloyd runsvdir /home/floyd/service}
-      its(:content) { should match regexp }
-    end
-  end
-
-  # timer
-  describe 'creates a service using sv_timeout' do
-    describe command('ps -ef | grep -v grep | grep "runsv timer"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should match(/runsv timer/) }
-    end
-    # FIXME: add something here
-  end
-
-  # chatterbox
-  describe 'creates a service using sv_verbose' do
-    describe command('ps -ef | grep -v grep | grep "runsv chatterbox"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should match(/runsv chatterbox/) }
-    end
-    # FIXME: add something here
-  end
-
-  # floyds-app
-  describe 'creates a service running by a normal user in its runsvdir' do
-    describe command('ps -ef | grep -v grep | grep "runsv floyds-app"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should match(/runsv floyds-app/) }
-    end
-
-    describe file('/etc/init.d/floyds-app') do
-      it { should be_mode 755 }
-      it { should be_owned_by 'root' }
-      it { should be_grouped_into 'root' }
-    end
-
-    describe file('/home/floyd/service/floyds-app') do
-      it { should be_symlink }
-      it { should be_owned_by 'root' }
-      it { should be_grouped_into 'root' }
-    end
-
-    describe file('/home/floyd/service/floyds-app/run') do
-      it { should be_mode 755 }
-      it { should be_owned_by 'floyd' }
-      it { should be_grouped_into 'floyd' }
-    end
-
-    describe file('/home/floyd/service/floyds-app/log') do
-      it { should be_directory }
-      it { should be_mode 755 }
-      it { should be_owned_by 'floyd' }
-      it { should be_grouped_into 'floyd' }
-    end
-
-    describe file('/home/floyd/service/floyds-app/log/run') do
-      it { should be_mode 755 }
-      it { should be_owned_by 'floyd' }
-      it { should be_grouped_into 'floyd' }
-    end
-  end
-
-  # yerba
-  describe 'creates a service with differently named template files' do
-    describe command('ps -ef | grep -v grep | grep "runsv yerba"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should match(/runsv yerba/) }
-    end
-    # FIXME: add something here
-  end
-
-  # yerba-alt
-  describe 'creates a service with differently named run script template' do
-    describe command('ps -ef | grep -v grep | grep "runsv yerba-alt"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should match(/runsv yerba-alt/) }
-    end
-    # FIXME: add something here
-  end
-
-  # ayahuasca
-  describe 'creates a service with a template from another cookbook' do
-    describe command('ps -ef | grep -v grep | grep "runsv ayahuasca"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should match(/runsv ayahuasca/) }
-    end
-  end
-
-  # exist-disabled
-  describe 'creates a service that should exist but be disabled' do
-    describe command('ps -ef | grep -v grep | grep "runsv control-signals"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should_not match(/runsv exist-disabled/) }
-    end
-
-    describe file('/etc/sv/exist-disabled/run') do
-      it { should be_mode 755 }
-      it { should be_owned_by 'root' }
-      it { should be_grouped_into 'root' }
-    end
-  end
-
-  # alternative-sv-bin
-  describe 'creates a service with an alternative sv_bin' do
-    describe command('ps -ef | grep -v grep | grep "runsv alternative-sv-bin"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should match(/runsv alternative-sv-bin/) }
-    end
-
-    describe file('/etc/init.d/alternative-sv-bin') do
-      its(:content) { should match(/^RUNIT=\/usr\/local\/bin\/sv$/) }
-    end
-  end
-
 end

--- a/test/integration/service/serverspec/linux_spec.rb
+++ b/test/integration/service/serverspec/linux_spec.rb
@@ -1,337 +1,105 @@
-require 'serverspec'
-
-set :backend, :exec
-
-puts "os: #{os}"
+require 'spec_helper'
+require 'service_example_groups'
 
 if %w( redhat fedora ubuntu ).include? os[:family]
 
-  # plain-defaults
-  describe 'creates a service with the defaults' do
-    describe command('ps -ef | grep -v grep | grep "runsv plain-defaults"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should match(/runsv plain-defaults/) }
-    end
+  describe "runit_test::service on #{os}" do
 
-    describe file('/etc/init.d/plain-defaults') do
-      it { should be_symlink }
-      it { should be_owned_by 'root' }
-      it { should be_grouped_into 'root' }
-    end
-
-    describe file('/etc/service/plain-defaults') do
-      it { should be_symlink }
-      it { should be_owned_by 'root' }
-      it { should be_grouped_into 'root' }
-    end
-
-    describe file('/etc/service/plain-defaults/run') do
-      it { should be_mode 755 }
-      it { should be_owned_by 'root' }
-      it { should be_grouped_into 'root' }
-    end
-
-    describe file('/etc/service/plain-defaults/log') do
-      it { should be_directory }
-      it { should be_mode 755 }
-      it { should be_owned_by 'root' }
-      it { should be_grouped_into 'root' }
-    end
-
-    describe file('/etc/service/plain-defaults/log/run') do
-      it { should be_mode 755 }
-      it { should be_owned_by 'root' }
-      it { should be_grouped_into 'root' }
-    end
-  end
-
-  # no-svlog
-  describe 'creates a service that doesnt use the svlog' do
-    describe command('ps -ef | grep -v grep | grep "runsv no-svlog"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should match(/runsv no-svlog/) }
-    end
-
-    describe file('/etc/service/no-svlog/log') do
-      it { should_not be_directory }
-    end
-  end
-
-  # default-svlog
-  describe 'creates a service that uses the default svlog' do
-    describe command('ps -ef | grep -v grep | grep "runsv default-svlog"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should match(/runsv default-svlog/) }
-    end
-
-    describe file('/etc/service/default-svlog/log/run') do
-      it { should be_mode 755 }
-      it { should be_owned_by 'root' }
-      it { should be_grouped_into 'root' }
-      regexp = %r{#!/bin/sh\nexec svlogd -tt /var/log/default-svlog}
-      its(:content) { should match regexp }
-    end
-
-    # Send some random data to the service logs and wait for logs to be written
-    describe command('dd if=/dev/urandom bs=5K count=10 | strings --bytes=1 | socat - "TCP4:127.0.0.1:6701" && sleep 2') do
-      its(:exit_status) { should eq 0 }
-    end
-
-    describe command('file /var/log/default-svlog/*.s') do
-      its(:stdout) { should contain('gzip compressed data') }
-    end
-  end
-
-  # checker
-  describe 'creates a service that has a check script' do
-    describe command('ps -ef | grep -v grep | grep "runsv checker"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should match(/runsv checker/) }
-    end
-
-    describe file('/etc/service/checker/check') do
-      it { should be_mode 755 }
-      it { should be_owned_by 'root' }
-      it { should be_grouped_into 'root' }
-    end
-  end
-
-  # finisher
-  describe 'creates a service that has a finish script' do
-    describe command('ps -ef | grep -v grep | grep "runsv finisher"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should match(/runsv finisher/) }
-    end
-
-    describe file('/etc/service/finisher/finish') do
-      it { should be_mode 755 }
-      it { should be_owned_by 'root' }
-      it { should be_grouped_into 'root' }
-    end
-  end
-
-  # env-files
-  describe 'creates a service that uses env files' do
-    describe command('ps -ef | grep -v grep | grep "runsv env-files"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should match(/runsv env-files/) }
-    end
-
-    describe file('/etc/service/env-files/env/PATH') do
-      it { should be_mode 640 }
-      it { should be_owned_by 'root' }
-      it { should be_grouped_into 'root' }
-      regexp = %r{\$PATH:/opt/chef/embedded/bin}
-      its(:content) { should match regexp }
-    end
-  end
-
-  # template-options
-  describe 'creates a service that sets options for the templates' do
-    describe command('ps -ef | grep -v grep | grep "runsv template-options"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should match(/runsv template-options/) }
-    end
-
-    describe file('/etc/service/template-options/run') do
-      it { should be_mode 755 }
-      it { should be_owned_by 'root' }
-      it { should be_grouped_into 'root' }
-      regexp = '# Options are delicious'
-      its(:content) { should match regexp }
-    end
-  end
-
-  # control-signals
-  describe 'creates a service that uses control signal files' do
-    describe command('ps -ef | grep -v grep | grep "runsv control-signals"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should match(/runsv control-signals/) }
-    end
-
-    describe file('/etc/service/control-signals/control/u') do
-      it { should be_mode 755 }
-      it { should be_owned_by 'root' }
-      it { should be_grouped_into 'root' }
-      regexp = 'control signal up'
-      its(:content) { should match regexp }
-    end
-  end
-
-  # runsvdir-floyd
-  describe 'creates a runsvdir service for a normal user' do
-    describe command('ps -ef | grep -v grep | grep "runsv runsvdir-floyd"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should match(/runsv runsvdir-floyd/) }
-    end
-
-    describe file('/etc/service/runsvdir-floyd/run') do
-      it { should be_mode 755 }
-      it { should be_owned_by 'root' }
-      it { should be_grouped_into 'root' }
-      regexp = %r{exec chpst -ufloyd runsvdir /home/floyd/service}
-      its(:content) { should match regexp }
-    end
-  end
-
-  # timer
-  describe 'creates a service using sv_timeout' do
-    describe command('ps -ef | grep -v grep | grep "runsv timer"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should match(/runsv timer/) }
-    end
-    # FIXME: add something here
-  end
-
-  # chatterbox
-  describe 'creates a service using sv_verbose' do
-    describe command('ps -ef | grep -v grep | grep "runsv chatterbox"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should match(/runsv chatterbox/) }
-    end
-    # FIXME: add something here
-  end
-
-  # floyds-app
-  describe 'creates a service running by a normal user in its runsvdir' do
-    describe command('ps -ef | grep -v grep | grep "runsv floyds-app"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should match(/runsv floyds-app/) }
-    end
-
-    describe file('/etc/init.d/floyds-app') do
-      it { should be_symlink }
-      it { should be_owned_by 'root' }
-      it { should be_grouped_into 'root' }
-    end
-
-    describe file('/home/floyd/service/floyds-app') do
-      it { should be_symlink }
-      it { should be_owned_by 'root' }
-      it { should be_grouped_into 'root' }
-    end
-
-    describe file('/home/floyd/service/floyds-app/run') do
-      it { should be_mode 755 }
-      it { should be_owned_by 'floyd' }
-      it { should be_grouped_into 'floyd' }
-    end
-
-    describe file('/home/floyd/service/floyds-app/log') do
-      it { should be_directory }
-      it { should be_mode 755 }
-      it { should be_owned_by 'floyd' }
-      it { should be_grouped_into 'floyd' }
-    end
-
-    describe file('/home/floyd/service/floyds-app/log/run') do
-      it { should be_mode 755 }
-      it { should be_owned_by 'floyd' }
-      it { should be_grouped_into 'floyd' }
-    end
-  end
-
-  # yerba
-  describe 'creates a service with differently named template files' do
-    describe command('ps -ef | grep -v grep | grep "runsv yerba"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should match(/runsv yerba/) }
-    end
-    # FIXME: add something here
-  end
-
-  # yerba-alt
-  describe 'creates a service with differently named run script template' do
-    describe command('ps -ef | grep -v grep | grep "runsv yerba-alt"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should match(/runsv yerba-alt/) }
-    end
-    # FIXME: add something here
-  end
-
-  # ayahuasca
-  describe 'creates a service with a template from another cookbook' do
-    describe command('ps -ef | grep -v grep | grep "runsv ayahuasca"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should match(/runsv ayahuasca/) }
-    end
-  end
-
-  # exist-disabled
-  describe 'creates a service that should exist but be disabled' do
-    describe command('ps -ef | grep -v grep | grep "runsv control-signals"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should_not match(/runsv exist-disabled/) }
-    end
-
-    describe file('/etc/sv/exist-disabled/run') do
-      it { should be_mode 755 }
-      it { should be_owned_by 'root' }
-      it { should be_grouped_into 'root' }
-    end
-  end
-
-  # alternative-sv-bin
-  describe 'creates a service with an alternative sv_bin' do
-    describe command('ps -ef | grep -v grep | grep "runsv alternative-sv-bin"') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should match(/runsv alternative-sv-bin/) }
-    end
-
-    describe file('/etc/init.d/alternative-sv-bin') do
-      it { should be_symlink }
-      it { should be_linked_to('/usr/local/bin/sv') }
-    end
-  end
-
-  # downed service
-  describe 'creates and manages down file for service' do
-    describe 'creates a service with a default state of down' do
-      describe file('/etc/sv/downed-service-6702/run') do
-        it { should be_mode 755 }
-        it { should be_owned_by 'root' }
-        it { should be_grouped_into 'root' }
+    # plain-defaults
+    describe 'creates a service with the defaults' do
+      describe command('ps -ef | grep -v grep | grep "runsv plain-defaults"') do
+        its(:exit_status) { should eq 0 }
+        its(:stdout) { should match(/runsv plain-defaults/) }
       end
 
-      describe file('/etc/service/downed-service-6702') do
+      describe file('/etc/init.d/plain-defaults') do
         it { should be_symlink }
         it { should be_owned_by 'root' }
         it { should be_grouped_into 'root' }
       end
 
-      describe file('/etc/sv/downed-service-6702/down') do
-        it { should be_mode 644 }
+      describe file('/etc/service/plain-defaults') do
+        it { should be_symlink }
         it { should be_owned_by 'root' }
         it { should be_grouped_into 'root' }
       end
 
-      describe command('ps -ef | grep -v grep | grep "runsv downed-service-6702"') do
-        its(:exit_status) { should eq 0 }
-        its(:stdout) { should match(/runsv downed-service-6702/) }
-      end
-
-      describe command('netstat -tuplen | grep LISTEN | grep 6702') do
-        its(:exit_status) { should eq 1 }
-      end
-    end
-
-    describe 'leaves existing downfile in place when down true -> false' do
-      describe file('/etc/sv/un-downed-service/down') do
-        it { should be_mode 644 }
+      describe file('/etc/service/plain-defaults/run') do
+        it { should be_mode 755 }
         it { should be_owned_by 'root' }
         it { should be_grouped_into 'root' }
       end
 
-      describe command('ps -ef | grep -v grep | grep "runsv un-downed-service"') do
+      describe file('/etc/service/plain-defaults/log') do
+        it { should be_directory }
+        it { should be_mode 755 }
+        it { should be_owned_by 'root' }
+        it { should be_grouped_into 'root' }
+      end
+
+      describe file('/etc/service/plain-defaults/log/run') do
+        it { should be_mode 755 }
+        it { should be_owned_by 'root' }
+        it { should be_grouped_into 'root' }
+      end
+    end
+
+    it_behaves_like 'common runit_test services'
+
+    # the following specs are a little different on debian vs other distros,
+    # so they are not part of the common services example group
+    
+    # alternative-sv-bin
+    describe 'creates a service with an alternative sv_bin' do
+      describe command('ps -ef | grep -v grep | grep "runsv alternative-sv-bin"') do
         its(:exit_status) { should eq 0 }
-        its(:stdout) { should match(/runsv un-downed-service/) }
+        its(:stdout) { should match(/runsv alternative-sv-bin/) }
+      end
+
+      describe file('/etc/init.d/alternative-sv-bin') do
+        it { should be_symlink }
+        it { should be_linked_to('/usr/local/bin/sv') }
       end
     end
-    describe 'removes existing downfile when requested' do
-      describe file('/etc/sv/un-downed-service-deleted/down') do
-        it { should_not exist }
+
+    # floyds-app
+    describe 'creates a service running by a normal user in its runsvdir' do
+      describe command('ps -ef | grep -v grep | grep "runsv floyds-app"') do
+        its(:exit_status) { should eq 0 }
+        its(:stdout) { should match(/runsv floyds-app/) }
+      end
+
+      describe file('/etc/init.d/floyds-app') do
+        it { should be_symlink }
+        it { should be_owned_by 'root' }
+        it { should be_grouped_into 'root' }
+      end
+
+      describe file('/home/floyd/service/floyds-app') do
+        it { should be_symlink }
+        it { should be_owned_by 'root' }
+        it { should be_grouped_into 'root' }
+      end
+
+      describe file('/home/floyd/service/floyds-app/run') do
+        it { should be_mode 755 }
+        it { should be_owned_by 'floyd' }
+        it { should be_grouped_into 'floyd' }
+      end
+
+      describe file('/home/floyd/service/floyds-app/log') do
+        it { should be_directory }
+        it { should be_mode 755 }
+        it { should be_owned_by 'floyd' }
+        it { should be_grouped_into 'floyd' }
+      end
+
+      describe file('/home/floyd/service/floyds-app/log/run') do
+        it { should be_mode 755 }
+        it { should be_owned_by 'floyd' }
+        it { should be_grouped_into 'floyd' }
       end
     end
+
   end
-
 end


### PR DESCRIPTION
Owing to differences in Debian's implementation of runit, ServerSpec
tests for the 'service' suite are split between specs for Debian and
other Linux distributions. This has led to some tests being added only
to one set of specs, a problem I think we can solve using example groups.

Before:

```
       Finished in 3.27 seconds (files took 0.39613 seconds to load)
              99 examples, 0 failures

       Finished verifying <service-debian-78> (0m15.39s).
```
```
       Finished in 3.06 seconds (files took 0.44521 seconds to load)
              118 examples, 0 failures

       Finished verifying <service-ubuntu-1404> (0m13.07s).
```

After:
```
       Finished in 3.4 seconds (files took 0.42381 seconds to load)
              117 examples, 0 failures

       Finished verifying <service-debian-78> (0m14.97s).
```
```
       Finished in 3.05 seconds (files took 0.43216 seconds to load)
              118 examples, 0 failures

       Finished verifying <service-ubuntu-1404> (0m12.15s).
       -----> Kitchen is finished. (0m12.49s)
```