### PR TITLE
#60 in docker

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -25,6 +25,15 @@ platforms:
   - name: debian-7.8
     run_list:
     - recipe[apt]
+  - name: ubuntu-14.04-docker
+    transport:
+      name: docker_cli
+    driver:
+      name: docker_cli
+    driver_config:
+      dockerfile: KitchenDockerfile
+      image: phusion/baseimage:0.9.16
+      command: /sbin/my_init
 
 suites:
 - name: default

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'rubocop'
 group :integration do
   gem 'test-kitchen'
   gem 'kitchen-vagrant'
+  gem 'kitchen-docker_cli', '= 0.13.0'	
   gem 'librarian-chef'
 end
 

--- a/KitchenDockerfile
+++ b/KitchenDockerfile
@@ -1,0 +1,1 @@
+FROM <%= config[:image] %>

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -89,7 +89,7 @@ module RunitCookbook
     # baseimage-docker. 
     def runsvdir_running?
       cmd = "ps -A -o command | grep \"^/usr/bin/runsvdir -P"\
-        " #{parsed_service_dir}$\" -c"
+        " #{parsed_service_dir}$\" | grep -v grep -c"
       # check also if monitoring parsed_sv_dir ?
 
       result = shell_out(cmd) # not shell_out!, do not fail 
@@ -107,7 +107,7 @@ module RunitCookbook
       # "ps -A -o command" == show all the processes, but only 
       # columns with their commands (not pid, stat, etc.)
       cmd = "ps -A -o command | grep \"^runsv"\
-        " #{new_resource.service_name}$\" -c"
+        " #{new_resource.service_name}$\" | grep -v grep -c"
 
       result = shell_out(cmd) # not shell_out!, do not fail 
       # on non zero exit status, exit status == 1 means: 

--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -265,6 +265,7 @@ class Chef
           block do
             wait_for_service
           end
+          only_if { need_to_wait_for_service? }
           action :run
         end
       end

--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -260,14 +260,6 @@ class Chef
           to sv_dir_name
           action :create
         end
-
-        ruby_block "wait for #{new_resource.service_name} service socket" do
-          block do
-            wait_for_service
-          end
-          only_if { need_to_wait_for_service? }
-          action :run
-        end
       end
 
       # signals
@@ -285,16 +277,36 @@ class Chef
       action :nothing do
       end
 
+      # Invokes method: wait_for_service from a Chef Resource.
+      def run_resource_wait_for_service
+        ruby_block "wait for #{new_resource.service_name} service socket" do
+          block do
+            wait_for_service
+          end
+          only_if { need_to_wait_for_service? }
+          action :run
+        end
+      end
+
       action :restart do
-        restart_service
+        if inside_docker? && !runsvdir_running? # e.g. during `docker build`
+          Chef::Log.debug "not restarting #{new_resource} (runsvdir process not running and inside docker)"
+        else
+          run_resource_wait_for_service
+          restart_service
+          Chef::Log.info "#{new_resource} restarted"
+        end
       end
 
       action :start do
-        unless(running?)
+        if(running?)
+          Chef::Log.debug "#{new_resource} already running - nothing to do"
+        elsif inside_docker? && !runsvdir_running? 
+          Chef::Log.debug "not starting #{new_resource} (runsvdir process not running and inside docker)"
+        else 
+          run_resource_wait_for_service
           start_service
           Chef::Log.info "#{new_resource} started"
-        else
-          Chef::Log.debug "#{new_resource} already running - nothing to do"
         end
       end
 
@@ -307,12 +319,15 @@ class Chef
         end
       end
 
-      action :reload do
-        if(running?)
+      action :reload do   
+        if !(running?) 
+          Chef::Log.debug "#{new_resource} not running - nothing to do"
+        elsif inside_docker? && !runsvdir_running? 
+          Chef::Log.debug "not reloading #{new_resource} (runsvdir process not running and inside docker)"
+        else
+          run_resource_wait_for_service
           reload_service
           Chef::Log.info "#{new_resource} reloaded"
-        else
-          Chef::Log.debug "#{new_resource} not running - nothing to do"
         end
       end
 

--- a/test/cookbooks/runit_test/recipes/service.rb
+++ b/test/cookbooks/runit_test/recipes/service.rb
@@ -19,6 +19,17 @@
 
 include_recipe 'runit::default'
 
+def docker?
+  results = `cat /proc/1/cgroup`.strip.split("\n")
+  results.any? { |val| /docker/ =~ val }
+end
+if docker?
+  bash 'apt-get update' do
+    user 'root'
+    code 'apt-get update'
+  end
+end
+
 link '/usr/local/bin/sv' do
   to '/usr/bin/sv'
 end


### PR DESCRIPTION
### Changes
In order to avoid the error `STDOUT: warning: /etc/service/<service_name>: unable to open supervise/ok: file does not exist` which occurred when running in Docker container, I changed the method `wait_for_service` so that it waits for that file: `supervise/ok` even in Docker container. It does not go into infinite loop because I added the check if the `runsvdir` process is running (== monitoring a directory with services files). 

But then I bumped into another error `"fail: <service_name>: runsv not running"`.  So it's not enough to check if `supervise/ok` exists and thus I added another check if there is `runsv` process running (== monitoring that one service). Only then the service can be correctly started.

When using `runit_service` resource in docker container instantiated from [Phusion Baseimage](https://github.com/phusion/baseimage-docker), it was enough for me to use only `action :enable` (without `action: start`), because the `runsvdir` is running and should result in starting that service anyway. 

### Tests
I added the Docker platform in `.kitchen.yml` for integration tests, using `kitchen-docker_cli` kitchen driver (no ssh here). I ran the tests in Docker container and also in Debian 7.8 virtual machine. In each case there was 1 error: 
```
Failures:

  1) runit_test::service on {:family=>"ubuntu", :release=>"14.04", :arch=>"x86_64"} behaves like common runit_test services creates a service that uses the default svlog Command "file /var/log/default-svlog/*.s" stdout should contain "gzip compressed data"
     Failure/Error: its(:stdout) { should contain('gzip compressed data') }
       expected "/var/log/default-svlog/*.s: ERROR: cannot open `/var/log/default-svlog/*.s' (No such file or directory)\n" to contain "gzip compressed data"
     Shared Example Group: "common runit_test services" called from /tmp/verifier/suites/serverspec/linux_spec.rb:47
     # /tmp/verifier/suites/serverspec/service_example_groups.rb:38:in `block (4 levels) in <top (required)>'

Finished in 4.12 seconds (files took 0.85474 seconds to load)
118 examples, 1 failure
```

This may need further testing. I will depend on this in other cookbooks and report here any problems with this PR or update the PR.  