### PR TITLE
Remove unnecessary default causing 12.5 "frozen" error

### DIFF
--- a/libraries/resource_runit_service.rb
+++ b/libraries/resource_runit_service.rb
@@ -124,12 +124,14 @@ class Chef
       end
 
       def options(arg = nil)
-        @env.empty? ? opts = @options : opts = @options.merge!(env_dir: ::File.join(@sv_dir, @service_name, 'env'))
+        if !@env.empty?
+          @options.merge!(env_dir: ::File.join(@sv_dir, @service_name, 'env'))
+        end
+
         set_or_return(
           :options,
           arg,
-          kind_of: [Hash],
-          default: opts
+          kind_of: [Hash]
         )
       end
 


### PR DESCRIPTION
Defaults will only be used if `@options` is `nil`.
In the case of `@env.empty?`, it will just return `nil`.
The else case will fail if `@options` is `nil` anyway, so
it will never be used as a default.