### PR TITLE
#60 in docker - more clear

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -25,6 +25,15 @@ platforms:
   - name: debian-7.8
     run_list:
     - recipe[apt]
+  - name: ubuntu-14.04-docker
+    transport:
+      name: docker_cli
+    driver:
+      name: docker_cli
+    driver_config:
+      dockerfile: KitchenDockerfile
+      image: phusion/baseimage:0.9.16
+      command: /sbin/my_init
 
 suites:
 - name: default

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'rubocop'
 group :integration do
   gem 'test-kitchen'
   gem 'kitchen-vagrant'
+  gem 'kitchen-docker_cli', '= 0.13.0'
   gem 'librarian-chef'
 end
 

--- a/KitchenDockerfile
+++ b/KitchenDockerfile
@@ -1,0 +1,1 @@
+FROM <%= config[:image] %>

--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -261,10 +261,19 @@ class Chef
           action :create
         end
 
+        # It seems ok to wait for service socket in action :enable in order 
+        # to do it once. The reason for doubt is: what if someone uses a resource 
+        # which notifies e.g. runit_service restart action? The service socket
+        # should exist in such a situation before actual restart. But it seems 
+        # reasonable to expect that any runit_service resource usage 
+        # should first use action :enable and then any other action.
         ruby_block "wait for #{new_resource.service_name} service socket" do
           block do
             wait_for_service
           end
+          # (!inside_docker || runsvdir_running?) is to avoid infinite loop of waiting
+          # It says if we can wait for service. 
+          only_if { (!inside_docker? || runsvdir_running?) && need_to_wait_for_service? }
           action :run
         end
       end
@@ -285,15 +294,22 @@ class Chef
       end
 
       action :restart do
-        restart_service
+        if inside_docker? && !runsvdir_running? # e.g. during `docker build`
+          Chef::Log.debug "not restarting #{new_resource} (runsvdir process not running and inside docker)"
+        else
+          restart_service
+          Chef::Log.info "#{new_resource} restarted"
+        end
       end
 
       action :start do
-        unless(running?)
+        if(running?)
+          Chef::Log.debug "#{new_resource} already running - nothing to do"
+        elsif inside_docker? && !runsvdir_running? 
+          Chef::Log.debug "not starting #{new_resource} (runsvdir process not running and inside docker)"
+        else
           start_service
           Chef::Log.info "#{new_resource} started"
-        else
-          Chef::Log.debug "#{new_resource} already running - nothing to do"
         end
       end
 
@@ -307,11 +323,13 @@ class Chef
       end
 
       action :reload do
-        if(running?)
+        if !(running?)
+          Chef::Log.debug "#{new_resource} not running - nothing to do"
+        elsif inside_docker? && !runsvdir_running? 
+          Chef::Log.debug "not reloading #{new_resource} (runsvdir process not running and inside docker)"
+        else
           reload_service
           Chef::Log.info "#{new_resource} reloaded"
-        else
-          Chef::Log.debug "#{new_resource} not running - nothing to do"
         end
       end
 

--- a/test/cookbooks/runit_test/recipes/service.rb
+++ b/test/cookbooks/runit_test/recipes/service.rb
@@ -19,6 +19,17 @@
 
 include_recipe 'runit::default'
 
+def docker?
+  results = `cat /proc/1/cgroup`.strip.split("\n")
+  results.any? { |val| /docker/ =~ val }
+end
+if docker?
+  bash 'apt-get update' do
+    user 'root'
+    code 'apt-get update'
+  end
+end
+
 link '/usr/local/bin/sv' do
   to '/usr/bin/sv'
 end


### PR DESCRIPTION
*This is a better, more clear version of [that PR](https://github.com/hw-cookbooks/runit/pull/146), which you can ignore*

### Resolved errors
When running in Docker container I ran into those errors:
 1. `STDOUT: warning: /etc/service/<service_name>: unable to open supervise/ok: file does not exist`. Thus I changed the method `wait_for_service` so that it waits for that file: `supervise/ok` not only in vm, but also in Docker container. The [ruby_block](https://github.com/ai-traders/runit/blob/%2360_in_docker_better/libraries/provider_runit_service.rb#L270) that invokes this method is idempotent and does not go into infinite loop (because of the check if `runsvdir` process is running (== monitoring a directory with services files)). (https://github.com/hw-cookbooks/runit/issues/60)
 2. `"fail: <service_name>: runsv not running"`. It shows that it's not enough to check if `supervise/ok` exists and thus I added another check, if `runsv` process is running (== monitoring that one service). Only then the service can be correctly started.

When using `runit_service` resource in docker container instantiated from [Phusion Baseimage](https://github.com/phusion/baseimage-docker), it was enough for me to use only `action :enable` (without `action: start`), because the `runsvdir` is running and should result in starting that service anyway. Using also `action :start` works too. 

Checking, if `runsvdir` process is running, is crucial in Docker container, because when running `kitchen converge`, that process is running, but it is not when running `docker build`.

### Tests
I added the Docker platform in `.kitchen.yml` for integration tests, using `kitchen-docker_cli` kitchen driver (no ssh here). I ran the tests in Docker container and also in Debian 7.8 virtual machine. In each case there was 1 error: 
```
Failures:

  1) runit_test::service on {:family=>"ubuntu", :release=>"14.04", :arch=>"x86_64"} behaves like common runit_test services creates a service that uses the default svlog Command "file /var/log/default-svlog/*.s" stdout should contain "gzip compressed data"
     Failure/Error: its(:stdout) { should contain('gzip compressed data') }
       expected "/var/log/default-svlog/*.s: ERROR: cannot open `/var/log/default-svlog/*.s' (No such file or directory)\n" to contain "gzip compressed data"
     Shared Example Group: "common runit_test services" called from /tmp/verifier/suites/serverspec/linux_spec.rb:47
     # /tmp/verifier/suites/serverspec/service_example_groups.rb:38:in `block (4 levels) in <top (required)>'

Finished in 4.12 seconds (files took 0.85474 seconds to load)
118 examples, 1 failure
```

### Conclusion
There are comments in code, so I assume no more explanation is needed here. 

I depended on this in other cookbooks and it worked. 