### PR TITLE
Removes extra braket from README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,8 +353,8 @@ runit_service "memcached" do
   options({
     :memory => node[:memcached][:memory],
     :port => node[:memcached][:port],
-    :user => node[:memcached][:user]}.merge(params)
-  })
+    :user => node[:memcached][:user]
+  }.merge(params))
 end
 ```
 


### PR DESCRIPTION
There was an extra closing bracket in the code example for the `options` example for the `runit_sevice` block.  Wasn't sure styleguide-wise which bracket you preferred to keep, so I went with the one I thought looked best.

Not sure if I am following the [contributing guidelines](https://github.com/hw-cookbooks/runit/blob/develop/CONTRIBUTING.md) correctly for this project, but it also seems like it might be copy-pasta from another "Chef CORP Proper" cookbook, so I just went with a simple github PR.  Feel free to close and implement this minor fix in a different release as you see fit.


Thanks for the great cookbook!