### PR TITLE
add manage_env_dir attribute

### DIFF
--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -150,9 +150,9 @@ class Chef
             end
           end
 
-          ruby_block 'zap extra env files' do
+          ruby_block "zap extra env files for #{new_resource.name} service" do
             block { zap_extra_env_files }
-            only_if { extra_env_files? }
+            only_if { new_resource.manage_env_dir && extra_env_files? }
             action :run
           end
 

--- a/libraries/resource_runit_service.rb
+++ b/libraries/resource_runit_service.rb
@@ -44,6 +44,7 @@ class Chef
         @control = []
         @options = {}
         @env = {}
+        @manage_env_dir = false
         @log = true
         @cookbook = nil
         @check = false
@@ -136,6 +137,10 @@ class Chef
 
       def env(arg = nil)
         set_or_return(:env, arg, kind_of: [Hash])
+      end
+
+      def manage_env_dir(arg = nil)
+        set_or_return(:manage_env_dir, arg, kind_of: [TrueClass, FalseClass])
       end
 
       ## set log to current instance value if nothing is passed.

--- a/test/cookbooks/runit_test/recipes/service.rb
+++ b/test/cookbooks/runit_test/recipes/service.rb
@@ -53,6 +53,20 @@ end
   end
 end
 
+# drop off environment files outside of the runit_service resources
+# so we can test manage_env_dir behavior
+%w(plain-defaults env-files).each do |svc|
+  directory "#{node['runit']['sv_dir']}/#{svc}/env" do
+    recursive true
+    action :nothing
+  end.run_action(:create)
+
+  file "#{node['runit']['sv_dir']}/#{svc}/env/ZAP_TEST" do
+    content '1'
+    action :nothing
+  end.run_action(:create)
+end
+
 # Create a service with all the fixin's
 runit_service 'plain-defaults'
 

--- a/test/cookbooks/runit_test/recipes/service.rb
+++ b/test/cookbooks/runit_test/recipes/service.rb
@@ -79,9 +79,10 @@ runit_service 'finisher' do
   finish true
 end
 
-# Create a service that uses env files
+# Create a service that uses env files and manages the contents of the env directory
 runit_service 'env-files' do
   env('PATH' => '$PATH:/opt/chef/embedded/bin')
+  manage_env_dir true
 end
 
 # Create a service that sets options for the templates

--- a/test/integration/helpers/serverspec/service_example_groups.rb
+++ b/test/integration/helpers/serverspec/service_example_groups.rb
@@ -1,6 +1,14 @@
 require 'spec_helper'
 
 shared_examples_for 'common runit_test services' do
+  # plain-defaults
+  describe 'does not delete unknown environment files in env dir when manage_env_dir is false' do
+    describe file('/etc/service/plain-defaults/env/ZAP_TEST') do
+      it { should exist }
+      its(:content) { should eq '1' }
+    end
+  end
+
   # no-svlog
   describe 'creates a service that doesnt use the svlog' do
     describe command('ps -ef | grep -v grep | grep "runsv no-svlog"') do
@@ -80,6 +88,11 @@ shared_examples_for 'common runit_test services' do
       regexp = %r{\$PATH:/opt/chef/embedded/bin}
       its(:content) { should match regexp }
     end
+  end
+
+  it 'deletes unknown environment files in env dir when manage_env_dir is true' do
+    pending 'zap extra env files ruby block running in first converge'
+    expect(file('/etc/service/env-files/env/ZAP_TEST')).to_not exist
   end
 
   # template-options

--- a/test/unit/runit_service/step_into_service_spec.rb
+++ b/test/unit/runit_service/step_into_service_spec.rb
@@ -94,6 +94,10 @@ describe 'runit_service' do
     let(:service_options) { Hash.new }
 
     it_behaves_like 'runit_service with logging'
+
+    it 'does not zap extra env files' do
+      expect(chef_run).to_not run_ruby_block('zap extra env files for plain-defaults service')
+    end
   end
 
   context 'with the log attribute set to false' do
@@ -210,6 +214,10 @@ describe 'runit_service' do
       expect(chef_run).to render_file(::File.join(service_svdir, 'env', 'PATH')).with_content(
         '$PATH:/opt/chef/embedded/bin'
       )
+    end
+
+    it 'zaps any extra env files' do
+      expect(chef_run).to run_ruby_block('zap extra env files for env-files service')
     end
   end
 


### PR DESCRIPTION
Per #144, deleting any files in the environment directory not created by the
runit_service instance breaks other cookbooks that rely on
runit_service and manage the contents of the env dir "out of band".
This change restores the default behavior prior to the 1.7 release,
adding a `manage_env_dir` attribute with a default value of
`false`. Setting `manage_env_dir` to `true` activates the behavior to
delete any files in the env dir which were not passed as part of the
runit_service's `env` hash.