### PR TITLE
Creating the service dir if it does not exist yet

### DIFF
--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -256,6 +256,8 @@ class Chef
         # FIXME: remove action_create in next major version
         action_create
 
+        directory new_resource.service_dir
+
         link "#{service_dir_name}" do
           to sv_dir_name
           action :create

--- a/test/unit/runit_service/step_into_service_spec.rb
+++ b/test/unit/runit_service/step_into_service_spec.rb
@@ -29,6 +29,10 @@ describe 'runit_service' do
       expect(chef_run).to create_directory(service_svdir)
     end
 
+    it 'creates the service directory' do
+      expect(chef_run).to create_directory(service_dir)
+    end
+
     it 'renders run script into service configuration directory' do
       expect(chef_run).to create_template(::File.join(service_svdir, 'run')).with(
         mode: '0755',


### PR DESCRIPTION
On ubuntu 14.04, /etc/service doesn't seem to exist by default, making `runit_service`resources crash.