### PR TITLE
Fix regression in `options` attribute

### DIFF
--- a/libraries/resource_runit_service.rb
+++ b/libraries/resource_runit_service.rb
@@ -125,12 +125,15 @@ class Chef
       end
 
       def options(arg = nil)
-        opts = @env.empty? ? @options : @options.merge(env_dir: ::File.join(@sv_dir, @service_name, 'env'))
+        default_opts = @env.empty? ? @options : @options.merge(env_dir: ::File.join(@sv_dir, @service_name, 'env'))
+
+        merged_opts = arg.respond_to?(:merge) ? default_opts.merge(arg) : default_opts
+
         set_or_return(
           :options,
-          arg,
+          merged_opts,
           kind_of: [Hash],
-          default: opts
+          default: default_opts
         )
       end
 

--- a/test/unit/runit_service/step_into_service_spec.rb
+++ b/test/unit/runit_service/step_into_service_spec.rb
@@ -213,6 +213,21 @@ describe 'runit_service' do
     end
   end
 
+  context 'with template options' do
+    let(:service) { chef_run.runit_service('template-options') }
+    let(:service_svdir) { ::File.join(sv_dir, service.name) }
+    let(:service_servicedir) { ::File.join(service_dir, service.name) }
+    let(:service_options) do
+      { raspberry: 'delicious' }
+    end
+
+    it_behaves_like 'runit_service with logging'
+
+    it 'renders the service run script with template options' do
+      expect(chef_run).to render_file(::File.join(service_svdir, 'run')).with_content(/# Options are delicious/)
+    end
+  end
+
   context 'with custom control script' do
     let(:service) { chef_run.runit_service('control-signals') }
     let(:service_svdir) { ::File.join(sv_dir, service.name) }


### PR DESCRIPTION
After merging #150 we are seeing a failed unit test:

```
Failures:

  1) runit_service with environment attributes behaves like
  runit_service with logging behaves like runit_service renders run
  script into service configuration directory
       Failure/Error: expect(chef_run).to
  create_template(::File.join(service_svdir, 'run')).with(
         expected "template[/etc/sv/env-files/run]" to have parameters:

         variables {:options=>{:env_dir=>"/etc/sv/env-files/env"}}, was
         {:options=>{}}
              Shared Example Group: "runit_service" called from
         ./test/unit/runit_service/step_into_service_spec.rb:67
              Shared Example Group: "runit_service with logging" called
         from ./test/unit/runit_service/step_into_service_spec.rb:203
              #
         ./test/unit/runit_service/step_into_service_spec.rb:33:in
         `block (3 levels) in <top (required)>'
```

This change set ensures the merged options are passed and adds more unit test coverage for the `options` attribute.