### PR TITLE
Revert `manage_env_dir` feature, fix env dir management regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,10 @@ Many of these parameters are only used in the `:enable` action.
    compatibility with legacy runit service definition. Default is an
    empty hash.
 - **env** - A hash of environment variables with their values as content
-   used in the service's `env` directory. Default is an empty hash.
+  used in the service's `env` directory. Default is an empty hash. When
+  this hash is non-empty, the contents of the runit service's `env`
+  directory will be managed by Chef in order to conform to the declared
+  state.
 - **log** - Whether to start the service's logger with svlogd, requires
    a template `sv-service_name-log-run.erb` to configure the log's run
    script. Default is true.

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -65,7 +65,7 @@ module RunitCookbook
 
     def extra_env_files?
       files = []
-      Dir.glob("#{service_dir_name}/env/*").each do |f|
+      Dir.glob("#{sv_dir_name}/env/*").each do |f|
         files << File.basename(f)
       end
       return true if files.sort != new_resource.env.keys.sort
@@ -73,7 +73,7 @@ module RunitCookbook
     end
 
     def zap_extra_env_files
-      Dir.glob("#{service_dir_name}/env/*").each do |f|
+      Dir.glob("#{sv_dir_name}/env/*").each do |f|
         unless new_resource.env.key?(File.basename(f))
           File.unlink(f)
           Chef::Log.info("removing file #{f}")

--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -150,9 +150,9 @@ class Chef
             end
           end
 
-          ruby_block "zap extra env files for #{new_resource.name} service" do
+          ruby_block 'zap extra env files' do
             block { zap_extra_env_files }
-            only_if { new_resource.manage_env_dir && extra_env_files? }
+            only_if { extra_env_files? }
             action :run
           end
 

--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -150,9 +150,10 @@ class Chef
             end
           end
 
-          ruby_block 'zap extra env files' do
+          ruby_block "zap extra env files for #{new_resource.name} service" do
             block { zap_extra_env_files }
             only_if { extra_env_files? }
+            not_if { new_resource.env.empty? }
             action :run
           end
 

--- a/libraries/resource_runit_service.rb
+++ b/libraries/resource_runit_service.rb
@@ -44,7 +44,6 @@ class Chef
         @control = []
         @options = {}
         @env = {}
-        @manage_env_dir = false
         @log = true
         @cookbook = nil
         @check = false
@@ -140,10 +139,6 @@ class Chef
 
       def env(arg = nil)
         set_or_return(:env, arg, kind_of: [Hash])
-      end
-
-      def manage_env_dir(arg = nil)
-        set_or_return(:manage_env_dir, arg, kind_of: [TrueClass, FalseClass])
       end
 
       ## set log to current instance value if nothing is passed.

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -65,7 +65,7 @@ when 'debian', 'gentoo'
     action :install
     response_file 'runit.seed' if platform?('ubuntu', 'debian')
     notifies value_for_platform(
-      'debian' => { '4.0' => :run, 'default' => :nothing  },
+      'debian' => { '4.0' => :run, 'default' => :nothing },
       'ubuntu' => {
         'default' => :nothing,
         '9.04' => :run,

--- a/test/cookbooks/runit_test/recipes/service.rb
+++ b/test/cookbooks/runit_test/recipes/service.rb
@@ -53,6 +53,20 @@ end
   end
 end
 
+# drop off environment files outside of the runit_service resources
+# so we can test manage_env_dir behavior
+%w(plain-defaults env-files).each do |svc|
+  directory "#{node['runit']['sv_dir']}/#{svc}/env" do
+    recursive true
+    action :nothing
+  end.run_action(:create)
+
+  file "#{node['runit']['sv_dir']}/#{svc}/env/ZAP_TEST" do
+    content '1'
+    action :nothing
+  end.run_action(:create)
+end
+
 # Create a service with all the fixin's
 runit_service 'plain-defaults'
 

--- a/test/cookbooks/runit_test/recipes/service.rb
+++ b/test/cookbooks/runit_test/recipes/service.rb
@@ -93,10 +93,9 @@ runit_service 'finisher' do
   finish true
 end
 
-# Create a service that uses env files and manages the contents of the env directory
+# Create a service that uses env files
 runit_service 'env-files' do
   env('PATH' => '$PATH:/opt/chef/embedded/bin')
-  manage_env_dir true
 end
 
 # Create a service that sets options for the templates

--- a/test/cookbooks/runit_test/recipes/service.rb
+++ b/test/cookbooks/runit_test/recipes/service.rb
@@ -53,20 +53,6 @@ end
   end
 end
 
-# drop off environment files outside of the runit_service resources
-# so we can test manage_env_dir behavior
-%w(plain-defaults env-files).each do |svc|
-  directory "#{node['runit']['sv_dir']}/#{svc}/env" do
-    recursive true
-    action :nothing
-  end.run_action(:create)
-
-  file "#{node['runit']['sv_dir']}/#{svc}/env/ZAP_TEST" do
-    content '1'
-    action :nothing
-  end.run_action(:create)
-end
-
 # Create a service with all the fixin's
 runit_service 'plain-defaults'
 

--- a/test/integration/helpers/serverspec/service_example_groups.rb
+++ b/test/integration/helpers/serverspec/service_example_groups.rb
@@ -1,6 +1,14 @@
 require 'spec_helper'
 
 shared_examples_for 'common runit_test services' do
+  # plain-defaults
+  describe 'does not delete extra env files in env dir when the env attribute is empty' do
+    describe file('/etc/service/plain-defaults/env/ZAP_TEST') do
+      it { should exist }
+      its(:content) { should eq '1' }
+    end
+  end
+
   # no-svlog
   describe 'creates a service that doesnt use the svlog' do
     describe command('ps -ef | grep -v grep | grep "runsv no-svlog"') do
@@ -80,6 +88,11 @@ shared_examples_for 'common runit_test services' do
       regexp = %r{\$PATH:/opt/chef/embedded/bin}
       its(:content) { should match regexp }
     end
+  end
+
+  it 'deletes unknown environment files in env dir when manage_env_dir is true' do
+    pending 'zap extra env files ruby block running in first converge'
+    expect(file('/etc/service/env-files/env/ZAP_TEST')).to_not exist
   end
 
   # template-options

--- a/test/integration/helpers/serverspec/service_example_groups.rb
+++ b/test/integration/helpers/serverspec/service_example_groups.rb
@@ -91,7 +91,6 @@ shared_examples_for 'common runit_test services' do
   end
 
   it 'deletes unknown environment files in env dir when manage_env_dir is true' do
-    pending 'zap extra env files ruby block running in first converge'
     expect(file('/etc/service/env-files/env/ZAP_TEST')).to_not exist
   end
 

--- a/test/integration/helpers/serverspec/service_example_groups.rb
+++ b/test/integration/helpers/serverspec/service_example_groups.rb
@@ -1,14 +1,6 @@
 require 'spec_helper'
 
 shared_examples_for 'common runit_test services' do
-  # plain-defaults
-  describe 'does not delete unknown environment files in env dir when manage_env_dir is false' do
-    describe file('/etc/service/plain-defaults/env/ZAP_TEST') do
-      it { should exist }
-      its(:content) { should eq '1' }
-    end
-  end
-
   # no-svlog
   describe 'creates a service that doesnt use the svlog' do
     describe command('ps -ef | grep -v grep | grep "runsv no-svlog"') do
@@ -88,11 +80,6 @@ shared_examples_for 'common runit_test services' do
       regexp = %r{\$PATH:/opt/chef/embedded/bin}
       its(:content) { should match regexp }
     end
-  end
-
-  it 'deletes unknown environment files in env dir when manage_env_dir is true' do
-    pending 'zap extra env files ruby block running in first converge'
-    expect(file('/etc/service/env-files/env/ZAP_TEST')).to_not exist
   end
 
   # template-options

--- a/test/unit/runit_service/step_into_service_spec.rb
+++ b/test/unit/runit_service/step_into_service_spec.rb
@@ -94,6 +94,10 @@ describe 'runit_service' do
     let(:service_options) { Hash.new }
 
     it_behaves_like 'runit_service with logging'
+
+    it 'does not zap extra env files' do
+      expect(chef_run).to_not run_ruby_block('zap extra env files for plain-defaults service')
+    end
   end
 
   context 'with the log attribute set to false' do
@@ -210,6 +214,10 @@ describe 'runit_service' do
       expect(chef_run).to render_file(::File.join(service_svdir, 'env', 'PATH')).with_content(
         '$PATH:/opt/chef/embedded/bin'
       )
+    end
+
+    it 'zaps any extra env files' do
+      expect(chef_run).to run_ruby_block('zap extra env files for env-files service')
     end
   end
 

--- a/test/unit/runit_service/step_into_service_spec.rb
+++ b/test/unit/runit_service/step_into_service_spec.rb
@@ -94,10 +94,6 @@ describe 'runit_service' do
     let(:service_options) { Hash.new }
 
     it_behaves_like 'runit_service with logging'
-
-    it 'does not zap extra env files' do
-      expect(chef_run).to_not run_ruby_block('zap extra env files for plain-defaults service')
-    end
   end
 
   context 'with the log attribute set to false' do
@@ -214,10 +210,6 @@ describe 'runit_service' do
       expect(chef_run).to render_file(::File.join(service_svdir, 'env', 'PATH')).with_content(
         '$PATH:/opt/chef/embedded/bin'
       )
-    end
-
-    it 'zaps any extra env files' do
-      expect(chef_run).to run_ruby_block('zap extra env files for env-files service')
     end
   end
 


### PR DESCRIPTION
In preparing changelog notes for a new release I realized that we are adding a feature flag to block cleaning up the environment, when this might be better treated as a regression from the [behavior introduced in v1.6.0](https://github.com/hw-cookbooks/runit/blob/v1.6.0/libraries/provider_runit_service.rb#L108).

In the prior implementation, "zapping" env files which aren't explicitly declared in Chef is only called if the Chef runit_service resource has a non-empty `env` hash. The changes in #107 reimplemented the "zapping" behavior, but did not retain the same guard preventing action when `env` is empty. This change should resolve that regression.