### PR TITLE
Restore restart on update functionality and fix janky tests

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,7 +17,6 @@ platforms:
   - name: debian-8.1
     run_list: apt::default
   - name: fedora-21
-  - name: fedora-22
   - name: ubuntu-12.04
     run_list: apt::default
   - name: ubuntu-14.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in each version of the runit cookbook.
 UNRELEASED
 ----------
 * Restore `restart_on_update` functionality originally added in [#20](https://github.com/hw-cookbooks/runit/pull/20) and lost in the 1.7.0 refactor.
+* Update test cookbooks to fix broken tests revealed by restoring `restart_on_update` functionality. Now using socat instead of netcat.
 
 v1.7.4 (2015-10-13)
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file is used to list changes made in each version of the runit cookbook.
 
 UNRELEASED
 ----------
+* Restore `restart_on_update` functionality originally added in [#20](https://github.com/hw-cookbooks/runit/pull/20) and lost in the 1.7.0 refactor.
 
 v1.7.4 (2015-10-13)
 ----------

--- a/README.md
+++ b/README.md
@@ -182,7 +182,8 @@ Many of these parameters are only used in the `:enable` action.
     the run script is updated. Defaults to `true`. Set to `false` if
     the service shouldn't be restarted when the run script is updated.
 - **start_down** - Set the default state of the runit service to 'down' by creating
-    `<sv_dir>/down` file
+    `<sv_dir>/down` file. Defaults to `false`. Services using `start_down`
+    will not be notified to restart when their run script is updated.
 - **delete_downfile** - Delete previously created `<sv_dir>/down` file
 
 Unlike previous versions of the cookbook using the `runit_service` definition, the `runit_service` resource can be notified. See __Usage__ examples below.

--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -57,7 +57,7 @@ class Chef
             restart_service
           end
           action :nothing
-          only_if { new_resource.restart_on_update }
+          only_if { new_resource.restart_on_update && !new_resource.start_down }
         end
 
         ruby_block 'restart_log_service' do
@@ -66,7 +66,7 @@ class Chef
             restart_log_service
           end
           action :nothing
-          only_if { new_resource.restart_on_update }
+          only_if { new_resource.restart_on_update && !new_resource.start_down }
         end
 
         # sv_templates

--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -50,6 +50,25 @@ class Chef
 
       # actions
       action :create do
+
+        ruby_block 'restart_service' do
+          block do
+            action_enable
+            restart_service
+          end
+          action :nothing
+          only_if { new_resource.restart_on_update }
+        end
+
+        ruby_block 'restart_log_service' do
+          block do
+            action_enable
+            restart_log_service
+          end
+          action :nothing
+          only_if { new_resource.restart_on_update }
+        end
+
         # sv_templates
         if new_resource.sv_templates
 
@@ -69,6 +88,7 @@ class Chef
             mode '0755'
             variables(options: new_resource.options)
             action :create
+            notifies :run, 'ruby_block[restart_service]', :delayed
           end
 
           # log stuff
@@ -103,6 +123,7 @@ class Chef
               cookbook 'runit'
               source 'log-config.erb'
               variables(config: new_resource)
+              notifies :run, 'ruby_block[restart_log_service]', :delayed
               action :create
             end
 
@@ -117,6 +138,7 @@ class Chef
                 group new_resource.group
                 mode '00755'
                 action :create
+                notifies :run, 'ruby_block[restart_log_service]', :delayed
               end
             else
               template "#{sv_dir_name}/log/run" do
@@ -127,6 +149,7 @@ class Chef
                 cookbook template_cookbook
                 variables(options: new_resource.options)
                 action :create
+                notifies :run, 'ruby_block[restart_log_service]', :delayed
               end
             end
 

--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -50,7 +50,6 @@ class Chef
 
       # actions
       action :create do
-
         ruby_block 'restart_service' do
           block do
             action_enable

--- a/test/cookbooks/runit_other_test/templates/default/sv-ayahuasca-run.erb
+++ b/test/cookbooks/runit_other_test/templates/default/sv-ayahuasca-run.erb
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec nc -l 3005
+exec socat - TCP4-LISTEN:3005,fork

--- a/test/cookbooks/runit_test/recipes/service.rb
+++ b/test/cookbooks/runit_test/recipes/service.rb
@@ -20,7 +20,10 @@
 include_recipe 'runit::default'
 
 link '/usr/local/bin/sv' do
-  to '/usr/bin/sv'
+  to value_for_platform_family(
+    'default' => '/usr/bin/sv',
+    %w(rhel fedora) => '/sbin/sv'
+  )
 end
 
 package 'socat'

--- a/test/cookbooks/runit_test/recipes/service.rb
+++ b/test/cookbooks/runit_test/recipes/service.rb
@@ -28,10 +28,6 @@ end
 
 package 'socat'
 
-package 'netcat' do
-  package_name 'nc' if platform_family?('rhel', 'fedora')
-end
-
 package 'lsof' do
   package_name 'lsof' if platform_family?('rhel', 'fedora')
 end

--- a/test/cookbooks/runit_test/recipes/service.rb
+++ b/test/cookbooks/runit_test/recipes/service.rb
@@ -135,6 +135,7 @@ runit_service 'yerba' do
   log_template_name 'yerba-matte'
   check_script_template_name 'yerba-matte'
   finish_script_template_name 'yerba-matte'
+  log_dir '/var/log/yerba-matte'
 end
 
 # Create a service with differently named template file, using default logger with non-default log_dir

--- a/test/cookbooks/runit_test/templates/default/sv-alternative-sv-bin-run.erb
+++ b/test/cookbooks/runit_test/templates/default/sv-alternative-sv-bin-run.erb
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec nc -l 3008
+exec socat - TCP4-LISTEN:3008,fork

--- a/test/cookbooks/runit_test/templates/default/sv-calabash-run.erb
+++ b/test/cookbooks/runit_test/templates/default/sv-calabash-run.erb
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec nc -l 6712
+exec socat - TCP4-LISTEN:6712,fork

--- a/test/cookbooks/runit_test/templates/default/sv-chatterbox-run.erb
+++ b/test/cookbooks/runit_test/templates/default/sv-chatterbox-run.erb
@@ -1,4 +1,4 @@
 #!/bin/sh
 exec 2>&1
 sleep 2
-exec nc -l 6714
+exec socat - TCP4-LISTEN:6714,fork

--- a/test/cookbooks/runit_test/templates/default/sv-checker-run.erb
+++ b/test/cookbooks/runit_test/templates/default/sv-checker-run.erb
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec nc -l 6709
+exec socat - TCP4-LISTEN:6709,fork

--- a/test/cookbooks/runit_test/templates/default/sv-control-signals-run.erb
+++ b/test/cookbooks/runit_test/templates/default/sv-control-signals-run.erb
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec nc -l 6700
+exec socat - TCP4-LISTEN:6700,fork

--- a/test/cookbooks/runit_test/templates/default/sv-cook-2867-run.erb
+++ b/test/cookbooks/runit_test/templates/default/sv-cook-2867-run.erb
@@ -1,4 +1,4 @@
 #!/bin/sh
 exec 2>&1
 # open port for the ticket #, clever eh?
-exec nc -l 2867
+exec socat - TCP4-LISTEN:2867,fork

--- a/test/cookbooks/runit_test/templates/default/sv-downed-service-6702-run.erb
+++ b/test/cookbooks/runit_test/templates/default/sv-downed-service-6702-run.erb
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec nc -l 6702
+exec socat - TCP4-LISTEN:6702,fork

--- a/test/cookbooks/runit_test/templates/default/sv-env-files-run.erb
+++ b/test/cookbooks/runit_test/templates/default/sv-env-files-run.erb
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec nc -l 6703
+exec socat - TCP4-LISTEN:6703,fork

--- a/test/cookbooks/runit_test/templates/default/sv-exist-disabled-run.erb
+++ b/test/cookbooks/runit_test/templates/default/sv-exist-disabled-run.erb
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec nc -l 6704
+exec socat - TCP4-LISTEN:6704,fork

--- a/test/cookbooks/runit_test/templates/default/sv-finisher-run.erb
+++ b/test/cookbooks/runit_test/templates/default/sv-finisher-run.erb
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec nc -l 6705
+exec socat - TCP4-LISTEN:6705,fork

--- a/test/cookbooks/runit_test/templates/default/sv-floyds-app-run.erb
+++ b/test/cookbooks/runit_test/templates/default/sv-floyds-app-run.erb
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec nc -l 6706
+exec socat - TCP4-LISTEN:6706,fork

--- a/test/cookbooks/runit_test/templates/default/sv-no-svlog-run.erb
+++ b/test/cookbooks/runit_test/templates/default/sv-no-svlog-run.erb
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec nc -l 6707
+exec socat - TCP4-LISTEN:6707,fork

--- a/test/cookbooks/runit_test/templates/default/sv-plain-defaults-run.erb
+++ b/test/cookbooks/runit_test/templates/default/sv-plain-defaults-run.erb
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec nc -l 6708
+exec socat - TCP4-LISTEN:6708,fork

--- a/test/cookbooks/runit_test/templates/default/sv-template-options-run.erb
+++ b/test/cookbooks/runit_test/templates/default/sv-template-options-run.erb
@@ -1,4 +1,4 @@
 #!/bin/sh
 # Options are <%= @options[:raspberry] %>
 exec 2>&1
-exec nc -l 6710
+exec socat - TCP4-LISTEN:6710,fork

--- a/test/cookbooks/runit_test/templates/default/sv-timer-run.erb
+++ b/test/cookbooks/runit_test/templates/default/sv-timer-run.erb
@@ -1,4 +1,4 @@
 #!/bin/sh
 exec 2>&1
 sleep 2
-exec nc -l 6713
+exec socat - TCP4-LISTEN:6713,fork

--- a/test/cookbooks/runit_test/templates/default/sv-un-downed-service-deleted-run.erb
+++ b/test/cookbooks/runit_test/templates/default/sv-un-downed-service-deleted-run.erb
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec nc -l 6716
+exec socat - TCP4-LISTEN:6716,fork

--- a/test/cookbooks/runit_test/templates/default/sv-un-downed-service-run.erb
+++ b/test/cookbooks/runit_test/templates/default/sv-un-downed-service-run.erb
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec nc -l 6715
+exec socat - TCP4-LISTEN:6715,fork

--- a/test/cookbooks/runit_test/templates/default/sv-yerba-matte-log-run.erb
+++ b/test/cookbooks/runit_test/templates/default/sv-yerba-matte-log-run.erb
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec svlogd -tt <%= @options[:log_dir] %>
+exec svlogd -tt /var/log/yerba-matte

--- a/test/cookbooks/runit_test/templates/default/sv-yerba-run.erb
+++ b/test/cookbooks/runit_test/templates/default/sv-yerba-run.erb
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec nc -l 6711
+exec socat - TCP4-LISTEN:6711,fork

--- a/test/unit/runit_service/step_into_service_spec.rb
+++ b/test/unit/runit_service/step_into_service_spec.rb
@@ -67,12 +67,31 @@ describe 'runit_service' do
     end
   end
 
-  shared_examples_for 'runit_service with logging' do
+  # The naming of these logging-related shared example groups is confusing because
+  # the `default_logger` parameter defaults to false. Maybe in a future version we
+  # rename this to something potentially less confusing, like embedded_logger?
+  shared_examples_for 'runit_service with default_logger set to false'  do
+    it_behaves_like 'runit_service with default logging'
+
+    let(:log_run_script) { chef_run.template(::File.join(service_svdir, 'log', 'run')) }
+
+    it 'notifies the logger to restart when its run script is updated' do
+      expect(log_run_script).to notify('ruby_block[restart_log_service]').to(:run).delayed
+    end
+  end
+
+  shared_examples_for 'runit_service with default logging' do
     it_behaves_like 'runit_service'
+
+    let(:log_config_tmpl) { chef_run.template(::File.join(service_svdir, 'log', 'config')) }
 
     it 'creates directories for the service logger' do
       expect(chef_run).to create_directory(::File.join(service_svdir, 'log'))
       expect(chef_run).to create_directory(::File.join(service_svdir, 'log', 'main'))
+    end
+
+    it 'renders logger run script into service log configuration directory' do
+      expect(chef_run).to render_file(::File.join(service_svdir, 'log', 'run'))
     end
 
     it 'renders logger run script into service log configuration directory' do
@@ -89,6 +108,11 @@ describe 'runit_service' do
         variables: { config: service }
       )
     end
+
+    it 'notifies the logger to restart when its config is updated' do
+      expect(log_config_tmpl).to notify('ruby_block[restart_log_service]').to(:run).delayed
+    end
+
   end
 
   context 'with default attributes' do
@@ -97,7 +121,7 @@ describe 'runit_service' do
     let(:service_servicedir) { ::File.join(service_dir, service.name) }
     let(:service_options) { Hash.new }
 
-    it_behaves_like 'runit_service with logging'
+    it_behaves_like 'runit_service with default_logger set to false'
 
     it 'does not zap extra env files' do
       expect(chef_run).to_not run_ruby_block('zap extra env files for plain-defaults service')
@@ -122,13 +146,14 @@ describe 'runit_service' do
     end
   end
 
-  context 'with the default logger' do
+  context 'with default_logger enabled' do
     let(:service) { chef_run.runit_service('default-svlog') }
     let(:service_svdir) { ::File.join(sv_dir, service.name) }
     let(:service_servicedir) { ::File.join(service_dir, service.name) }
     let(:service_options) { Hash.new }
+    let(:log_run_script) { chef_run.file(::File.join(service_svdir, 'log', 'run')) }
 
-    it_behaves_like 'runit_service with logging'
+    it_behaves_like 'runit_service with default logging'
 
     it 'creates a service with the default_logger attribute set to true' do
       expect(service.default_logger).to eq(true)
@@ -150,6 +175,10 @@ describe 'runit_service' do
         to: ::File.join(service_svdir, 'log', 'config')
       )
     end
+
+    it 'notifies the logger to restart when its run script is updated' do
+      expect(log_run_script).to notify('ruby_block[restart_log_service]').to(:run).delayed
+    end
   end
 
   context 'with a check script' do
@@ -158,7 +187,7 @@ describe 'runit_service' do
     let(:service_servicedir) { ::File.join(service_dir, service.name) }
     let(:service_options) { Hash.new }
 
-    it_behaves_like 'runit_service with logging'
+    it_behaves_like 'runit_service with default_logger set to false'
 
     it 'creates a service with check attribute set to true' do
       expect(service.check).to eq(true)
@@ -182,7 +211,7 @@ describe 'runit_service' do
     let(:service_servicedir) { ::File.join(service_dir, service.name) }
     let(:service_options) { Hash.new }
 
-    it_behaves_like 'runit_service with logging'
+    it_behaves_like 'runit_service with default_logger set to false'
 
     it 'creates a service with finish attribute set to true' do
       expect(service.finish).to eq(true)
@@ -208,7 +237,7 @@ describe 'runit_service' do
       { env_dir: '/etc/sv/env-files/env' }
     end
 
-    it_behaves_like 'runit_service with logging'
+    it_behaves_like 'runit_service with default_logger set to false'
 
     it 'creates a service with a PATH environment variable' do
       expect(service.env).to have_key('PATH')
@@ -233,7 +262,7 @@ describe 'runit_service' do
       { raspberry: 'delicious' }
     end
 
-    it_behaves_like 'runit_service with logging'
+    it_behaves_like 'runit_service with default_logger set to false'
 
     it 'renders the service run script with template options' do
       expect(chef_run).to render_file(::File.join(service_svdir, 'run')).with_content(/# Options are delicious/)
@@ -247,7 +276,7 @@ describe 'runit_service' do
     let(:service_options) { Hash.new }
     let(:service_signal) { 'u' }
 
-    it_behaves_like 'runit_service with logging'
+    it_behaves_like 'runit_service with default_logger set to false'
 
     it 'writes custom control script for signal' do
       expect(chef_run).to create_template(::File.join(service_svdir, 'control', service_signal)).with(

--- a/test/unit/runit_service/step_into_service_spec.rb
+++ b/test/unit/runit_service/step_into_service_spec.rb
@@ -70,7 +70,7 @@ describe 'runit_service' do
   # The naming of these logging-related shared example groups is confusing because
   # the `default_logger` parameter defaults to false. Maybe in a future version we
   # rename this to something potentially less confusing, like embedded_logger?
-  shared_examples_for 'runit_service with default_logger set to false'  do
+  shared_examples_for 'runit_service with default_logger set to false' do
     it_behaves_like 'runit_service with default logging'
 
     let(:log_run_script) { chef_run.template(::File.join(service_svdir, 'log', 'run')) }
@@ -112,7 +112,6 @@ describe 'runit_service' do
     it 'notifies the logger to restart when its config is updated' do
       expect(log_config_tmpl).to notify('ruby_block[restart_log_service]').to(:run).delayed
     end
-
   end
 
   context 'with default attributes' do


### PR DESCRIPTION
I cherry-picked a commit from from @dcparker88's #149, and found that this missing functionality was masking a bunch of errors in the services we use for our integration tests. Should be fixed up now.

I also removed fedora-22 from test-kitchen platforms due to an upstream issue in Chef (see https://github.com/chef/chef/issues/3613)

Closes #145
Closes #149