### PR TITLE
Fixed implementation of "Remove the supervise/ok named pipe when disabling a service"

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -158,8 +158,15 @@ exec svlogd -tt #{new_resource.log_dir}
 
     def disable_service
       shell_out("#{new_resource.sv_bin} #{sv_args}down #{service_dir_name}")
-      FileUtils.rm("#{service_dir_name}/supervise/ok")
       FileUtils.rm(service_dir_name)
+
+      # per the documentation, a service should be removed from supervision
+      # within 5 seconds of removing the service dir symlink, so we'll sleep for 6.
+      # otherwise, runit recreates the 'ok' named pipe too quickly
+      sleep(6)
+      # runit will recreate the supervise directory and
+      # pipes when the service is reenabled
+      FileUtils.rm("#{sv_dir_name}/supervise/ok")
     end
 
     def start_service

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -158,6 +158,7 @@ exec svlogd -tt #{new_resource.log_dir}
 
     def disable_service
       shell_out("#{new_resource.sv_bin} #{sv_args}down #{service_dir_name}")
+      FileUtils.rm("#{service_dir_name}/supervise/ok")
       FileUtils.rm(service_dir_name)
     end
 

--- a/test/integration/helpers/serverspec/service_example_groups.rb
+++ b/test/integration/helpers/serverspec/service_example_groups.rb
@@ -213,6 +213,10 @@ shared_examples_for 'common runit_test services' do
       it { should be_owned_by 'root' }
       it { should be_grouped_into 'root' }
     end
+
+    describe file('/etc/sv/exist-disabled/supervise/ok') do
+      it { should_not exist }
+    end
   end
 
   # downed service


### PR DESCRIPTION
This PR includes the single commit from #167 and builds upon it, adding integration test coverage and adjusting the implementation to ensure runit doesn't recreate the `supervise/ok` pipe before the service is actually disabled

Closes #166 
Closes #167