### PR TITLE
Mark env files as sensitive

### DIFF
--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -167,7 +167,7 @@ class Chef
               owner new_resource.owner
               group new_resource.group
               content value
-              sensitive true if Chef::Resource::ChefGem.instance_methods(false).include?(:sensitive)
+              sensitive true if Chef::Resource.instance_methods(false).include?(:sensitive)
               mode 00640
               action :create
             end

--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -167,6 +167,7 @@ class Chef
               owner new_resource.owner
               group new_resource.group
               content value
+              sensitive true if Chef::Resource::ChefGem.instance_methods(false).include?(:sensitive)
               mode 00640
               action :create
             end

--- a/test/unit/runit_service/step_into_service_spec.rb
+++ b/test/unit/runit_service/step_into_service_spec.rb
@@ -249,7 +249,7 @@ describe 'runit_service' do
     end
 
     it 'sets the sensitive attribute on the env file resource' do
-      expect(chef_run).to render_file(::File.join(service_svdir, 'env', 'PATH'))
+      expect(chef_run).to create_file(::File.join(service_svdir, 'env', 'PATH'))
         .with(sensitive: true)
     end
 

--- a/test/unit/runit_service/step_into_service_spec.rb
+++ b/test/unit/runit_service/step_into_service_spec.rb
@@ -248,6 +248,11 @@ describe 'runit_service' do
       )
     end
 
+    it 'sets the sensitive attribute on the env file resource' do
+      expect(chef_run).to render_file(::File.join(service_svdir, 'env', 'PATH'))
+        .with(sensitive: true)
+    end
+
     it 'zaps any extra env files' do
       expect(chef_run).to run_ruby_block('zap extra env files for env-files service')
     end


### PR DESCRIPTION
This suppresses env file logging output in case of sensitive credentials making their way in to that directory. There is a fallback in case this is an older version of Chef that does not support sensitive as a common resource argument.