### PR TITLE
pin chef at ~> 12.5.0 in Gemfile to fix ChefSpec errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ end
 group :unit do
   gem 'berkshelf',  '~> 4.0'
   gem 'chefspec',   '~> 4.4'
+  gem 'chef',       '~> 12.5.0'
 end
 
 group :kitchen_common do


### PR DESCRIPTION
Seeing the following in chefspec tests after running `bundle update`. Pinning chef to ~> 12.5.0 makes it go away.

```
================================================================================
Recipe Compile Error in /var/folders/y4/ccjrk8mn4c74ynp2lc7kpnm80000gn/T/d20160318-99732-khya9u/runit_test/recipes/service.rb
================================================================================

ArgumentError
-------------
wrong number of arguments (1 for 0)

Cookbook Trace:
---------------
  /var/folders/y4/ccjrk8mn4c74ynp2lc7kpnm80000gn/T/d20160318-99732-khya9u/runit/recipes/default.rb:20:in `from_file'
    /var/folders/y4/ccjrk8mn4c74ynp2lc7kpnm80000gn/T/d20160318-99732-khya9u/runit_test/recipes/service.rb:20:in `from_file'

Relevant File Content:
----------------------
/var/folders/y4/ccjrk8mn4c74ynp2lc7kpnm80000gn/T/d20160318-99732-khya9u/runit/recipes/default.rb:

 13:  # Unless required by applicable law or agreed to in writing, software
 14:  # distributed under the License is distributed on an 'AS IS' BASIS,
 15:  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 16:  # See the License for the specific language governing permissions and
 17:  # limitations under the License.
 18:  #
 19:
 20>> service 'runit' do
 21:    action :nothing
 22:  end
 23:
 24:  execute 'start-runsvdir' do
 25:    command value_for_platform(
 26:      'debian' => { 'default' => 'runsvdir-start' },
 27:      'ubuntu' => { 'default' => 'start runsvdir' },
 28:      'gentoo' => { 'default' => '/etc/init.d/runit-start start' }
 29:    )
```