### PR TITLE
Delete broken and unnecessary docker check

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,30 @@ end
 For more examples, see the `runit_test` cookbook's `service` recipe in the [git repository](https://github.com/hw-cookbooks/runit).
 
 
+Development
+-----------
+
+You may use test kitchen with either the vagrant or docker drivers to run integration tests.
+
+**Note:** When using the docker driver please ensure that the container you are using has a working init system, as runit expects to be started by init. In some cases, systemd may need to be run in privileged mode.
+
+For instance, for ubuntu with upstart:
+
+```
+    driver_config:
+      image: ubuntu-upstart:14.04
+      run_command: /sbin/init
+```
+
+For redhat derivatives:
+
+```
+    driver_config:
+      image: dockerhub/image-with-systemd
+      run_command: /usr/sbin/init
+      privileged: true
+```
+
 License & Authors
 -----------------
 - Author:: Adam Jacob <adam@chef.io>

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -49,12 +49,6 @@ module RunitCookbook
       '/etc/init.d'
     end
 
-    # misc helper functions
-    def inside_docker?
-      results = `cat /proc/1/cgroup`.strip.split("\n")
-      results.any? { |val| /docker/ =~ val }
-    end
-
     def down_file
       "#{sv_dir_name}/down"
     end
@@ -82,12 +76,10 @@ module RunitCookbook
     end
 
     def wait_for_service
-      unless inside_docker?
-        sleep 1 until ::FileTest.pipe?("#{service_dir_name}/supervise/ok")
+      sleep 1 until ::FileTest.pipe?("#{service_dir_name}/supervise/ok")
 
-        if new_resource.log
-          sleep 1 until ::FileTest.pipe?("#{service_dir_name}/log/supervise/ok")
-        end
+      if new_resource.log
+        sleep 1 until ::FileTest.pipe?("#{service_dir_name}/log/supervise/ok")
       end
     end
 


### PR DESCRIPTION
fixes https://github.com/hw-cookbooks/runit/issues/100

It looks like this check was introduced in https://github.com/hw-cookbooks/runit/pull/61 a while ago, but the actual reasoning for why it polling for supervise/ok was causing infinite loops was never given. 

It might be that the underlying container filesystem didn't support pipes at the time, or maybe something to do with the way docker used to use lxc, but no reason is given.

There are no tests to support this logic either.

This check is preventing me from using the docker test kitchen driver. By removing this check, everything just works. Unless a concrete reason can be supplied for why this check is here, with test cases around it, I think that it should be removed, as I don't think it is valid anymore with a modern version of docker.

@slyness for review

@akranga can you provide more context on how the infinite loops were happening? Can you test this branch with a modern version of docker to see if the problem still happens?

I'd much prefer to solve this problem in a much less heavy handed way, if the problem still exists.

By updating the project kitchen.yml to use docker, I can now successfully run the test suite using docker here (which will actually probably make it easier to do a CI in travis with test kitchen now). So, I'm quite confident that this workaround is no longer needed, as the tests we *do* have pass without it , while using docker.

to reproduce my test kitchen tests with docker, here's the test kitchen file i've used: https://gist.github.com/dalehamel/9f801012342432224cf1725b3013e53c (a couple of them are commented out, because i haven't yet found docker images that will allow me to start systemd, which runsv requires for those distros)

fyi @coderanger