### PR TITLE
Explicitly install packages providing testing dependencies

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,9 +12,7 @@ platforms:
     run_list: apt::default
   - name: debian-8.2
     run_list: apt::default
-  - name: fedora-22
-    run_list: yum::dnf_yum_compat
-  - name: fedora-23
+  - name: fedora-21
     run_list: yum::dnf_yum_compat
   - name: ubuntu-12.04
     run_list: apt::default

--- a/Cheffile
+++ b/Cheffile
@@ -4,6 +4,7 @@ site 'https://supermarket.chef.io/api/v1'
 
 # loosely coupled prerequisites for test-kitchen
 cookbook 'apt'
+cookbook 'yum'
 cookbook 'yum-epel'
 
 cookbook 'runit', path: '.'

--- a/test/cookbooks/runit_test/recipes/service.rb
+++ b/test/cookbooks/runit_test/recipes/service.rb
@@ -28,11 +28,8 @@ end
 
 package 'binutils'
 package 'file'
+package 'lsof'
 package 'socat'
-
-package 'lsof' do
-  package_name 'lsof' if platform_family?('rhel', 'fedora')
-end
 
 # Create a normal user to run services later
 group 'floyd'

--- a/test/cookbooks/runit_test/recipes/service.rb
+++ b/test/cookbooks/runit_test/recipes/service.rb
@@ -26,6 +26,8 @@ link '/usr/local/bin/sv' do
   )
 end
 
+package 'binutils'
+package 'file'
 package 'socat'
 
 package 'lsof' do


### PR DESCRIPTION
Some docker containers we're testing with kitchen-docker lack packages which are present in the bento virtualbox images we've been using with kitchen-vagrant, i.e. `file` package to provide `file` command, `bintuils` package to provide `strings` command.